### PR TITLE
Update some TODO items

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,13 @@ A CLI tool for launching troubleshooting docker images into a kubernetes cluster
 
 ## TODO
 
-- Validate the name of the utility container
-- Display a list of choices of utility container if NO args[0] is passed in
-- Display a list of choices of K8s ServiceAccounts if no args[1] is passed in
-- Provide a switch to directly submit the manifest to the KUBECONFIG defined current context
-- Add a deeper definition for utility containers, specifying sizes (requests/limits)
+- [ ] Validate the name of the utility container?
+- [x] Display a list of choices of utility container if NO args[0] is passed in
+- [x] Display a list of choices of K8s ServiceAccounts if no args[1] is passed in
+- [x] Provide a switch to directly submit the manifest to the KUBECONFIG defined current context
+  - this is just default, no switch
+- [x] Add a deeper definition for utility containers, specifying sizes (requests/limits)
 - Add a check to see if the POD has already been created
-- Add a "delete" container switch
+- [x] Add a "delete" container command
+- [ ] Add a config.yaml based list of container details
+


### PR DESCRIPTION
## Description

Initial MVP release of a quick tool

## Motivation and Context

It will be nice to have a single tool to launch utility pods, and not have to always go searching

## Dependencies

## How Has This Been Tested?

TODO: we should have tests...

## Screenshots (if appropriate)

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [ ] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
- **BREAKING** note on base feature
- Basically whatever formatting we have here, just plain-text
%> command example
- next feature
- note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

- Utility pods for awscli, az cli, gcloud, psql, mysql, curl, dns and more have been defined
- Just running the ktrouble tool will prompt for all the info required to launch

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes
