### PR TITLE
Move utility definitions to the config.yaml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,26 @@ brew install maahsome/tap/ktrouble --formula
 - [x] Add a "delete" container command
 - [ ] Add a config.yaml based list of container details
 
+## PERSONAL JIRA LIST
 
+```zsh
+switch-jira kt
+jira readme
+```
+
+### To Do
+
+- [ ] KT-1:    Add EXAMPLES and Documentation 
+- [ ] KT-3:    Find and add an ansible container 
+- [ ] KT-6:    Convert to real OUTPUT formats 
+- [ ] KT-7:    Replace logrus with common.Logger 
+- [ ] KT-8:    In the delete command, when no pods are running, exit with that description 
+- [ ] KT-9:    Extend the delete command to look at the first param after delete and use that as the delete POD name 
+- [ ] KT-10:   Fix a bug where the utilitydefinitions are detected as empty, and defaults are written to config.yaml 
+- [ ] KT-11:   Read the utilitydefinitions into a global variable rather than re-read config all the time (both MAP and ARRAY) 
+
+### Done
+
+- [x] KT-4:        Add a LIST for running PODs
+- [x] KT-5:        Add a LIST for defined container images
+- [x] KT-2:        Move container list details to config.yaml, create an initial version

--- a/cmd/default.go
+++ b/cmd/default.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sYaml "k8s.io/apimachinery/pkg/util/yaml"
@@ -36,10 +37,24 @@ var defaultCmd = &cobra.Command{
 	Long: `EXAMPLE:
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		utilDefs := buildUtilityDefinitions()
-		// for i, v := range args {
-		// 	fmt.Printf("ARG: %d: %s\n", i, v)
-		// }
+		utilDefs := []UtilityPod{}
+		err := viper.UnmarshalKey("utilityDefinitions", &utilDefs)
+		if err != nil {
+			logrus.Fatal("Error unmarshalling utility defs...")
+		}
+		if len(utilDefs) == 0 {
+			utilDefs = defaultUtilityDefinitions()
+		}
+
+		utilMap := make(map[string]UtilityPod)
+		for _, v := range utilDefs {
+			utilMap[v.Name] = UtilityPod{
+				Name:        v.Name,
+				Repository:  v.Repository,
+				ExecCommand: v.ExecCommand,
+			}
+		}
+
 		utility := ""
 		if len(args) > 0 && len(args[0]) > 0 {
 			utility = args[0]
@@ -69,7 +84,7 @@ var defaultCmd = &cobra.Command{
 				"name":           fmt.Sprintf("%s-%s", utility, shortUniq),
 				"serviceAccount": sa,
 				"namespace":      namespace,
-				"registry":       utilDefs[utility].Repository,
+				"registry":       utilMap[utility].Repository,
 				"limitsCpu":      resourceSize["limitsCpu"],
 				"limitsMem":      resourceSize["limitsMem"],
 				"requestCpu":     resourceSize["requestCpu"],
@@ -92,7 +107,7 @@ var defaultCmd = &cobra.Command{
 
 		createPod(podManifest, namespace)
 
-		fmt.Printf("kubectl -n %s exec -it %s -- %s\n", namespace, fmt.Sprintf("%s-%s", utility, shortUniq), utilDefs[utility].ExecCommand)
+		fmt.Printf("kubectl -n %s exec -it %s -- %s\n", namespace, fmt.Sprintf("%s-%s", utility, shortUniq), utilMap[utility].ExecCommand)
 
 	},
 }
@@ -132,66 +147,67 @@ func createPod(podJSON string, namespace string) {
 	}
 	// fmt.Printf("Created pod %q.\n", result.GetObjectMeta().GetName())
 }
-func buildUtilityDefinitions() map[string]UtilityPod {
 
-	utilityDefinitions := make(map[string]UtilityPod, 0)
-	utilityDefinitions["dnsutils"] = UtilityPod{
-		Name:        "dnsutils",
-		Repository:  "gcr.io/kubernetes-e2e-test-images/dnsutils:1.3",
-		ExecCommand: "/bin/sh",
-	}
-	utilityDefinitions["psql-curl"] = UtilityPod{
-		Name:        "psql-curl",
-		Repository:  "barrypiccinni/psql-curl:latest",
-		ExecCommand: "/bin/bash",
-	}
-	utilityDefinitions["psqlutils15"] = UtilityPod{
-		Name:        "psqlutils15",
-		Repository:  "postgres:15-bullseye",
-		ExecCommand: "/bin/bash",
-	}
-	utilityDefinitions["psqlutils14"] = UtilityPod{
-		Name:        "psqlutils14",
-		Repository:  "postgres:14-bullseye",
-		ExecCommand: "/bin/bash",
-	}
-	utilityDefinitions["awscli"] = UtilityPod{
-		Name:        "awscli",
-		Repository:  "amazon/aws-cli:latest",
-		ExecCommand: "/bin/bash",
-	}
-	utilityDefinitions["gcloudutils"] = UtilityPod{
-		Name:        "gcloudutils",
-		Repository:  "google/cloud-sdk:latest",
-		ExecCommand: "/bin/bash",
-	}
-	utilityDefinitions["azutils"] = UtilityPod{
-		Name:        "azutils",
-		Repository:  "mcr.microsoft.com/azure-cli",
-		ExecCommand: "/bin/bash",
-	}
-	utilityDefinitions["mysqlutils5"] = UtilityPod{
-		Name:        "mysqlutils5",
-		Repository:  "mysql:5.7.40-debian",
-		ExecCommand: "/bin/bash",
-	}
-	utilityDefinitions["mysqlutils8"] = UtilityPod{
-		Name:        "mysqlutils8",
-		Repository:  "mysql:8-debian",
-		ExecCommand: "/bin/bash",
-	}
-	utilityDefinitions["redis6"] = UtilityPod{
-		Name:        "redis6",
-		Repository:  "cmaahs/redis-cli:6.2",
-		ExecCommand: "/bin/bash",
-	}
-	utilityDefinitions["curl"] = UtilityPod{
-		Name:        "curl",
-		Repository:  "curlimages/curl:latest",
-		ExecCommand: "/bin/sh",
+func defaultUtilityDefinitions() []UtilityPod {
+
+	return []UtilityPod{
+		{
+			Name:        "dnsutils",
+			Repository:  "gcr.io/kubernetes-e2e-test-images/dnsutils:1.3",
+			ExecCommand: "/bin/sh",
+		},
+		{
+			Name:        "psql-curl",
+			Repository:  "barrypiccinni/psql-curl:latest",
+			ExecCommand: "/bin/bash",
+		},
+		{
+			Name:        "psqlutils15",
+			Repository:  "postgres:15-bullseye",
+			ExecCommand: "/bin/bash",
+		},
+		{
+			Name:        "psqlutils14",
+			Repository:  "postgres:14-bullseye",
+			ExecCommand: "/bin/bash",
+		},
+		{
+			Name:        "awscli",
+			Repository:  "amazon/aws-cli:latest",
+			ExecCommand: "/bin/bash",
+		},
+		{
+			Name:        "gcloudutils",
+			Repository:  "google/cloud-sdk:latest",
+			ExecCommand: "/bin/bash",
+		},
+		{
+			Name:        "azutils",
+			Repository:  "mcr.microsoft.com/azure-cli",
+			ExecCommand: "/bin/bash",
+		},
+		{
+			Name:        "mysqlutils5",
+			Repository:  "mysql:5.7.40-debian",
+			ExecCommand: "/bin/bash",
+		},
+		{
+			Name:        "mysqlutils8",
+			Repository:  "mysql:8-debian",
+			ExecCommand: "/bin/bash",
+		},
+		{
+			Name:        "redis6",
+			Repository:  "cmaahs/redis-cli:6.2",
+			ExecCommand: "/bin/bash",
+		},
+		{
+			Name:        "curl",
+			Repository:  "curlimages/curl:latest",
+			ExecCommand: "/bin/sh",
+		},
 	}
 
-	return utilityDefinitions
 }
 
 func init() {

--- a/cmd/get_utilities.go
+++ b/cmd/get_utilities.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // utilitiesCmd represents the namespace command
@@ -16,7 +18,14 @@ var utilitiesCmd = &cobra.Command{
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		utilDefs := buildUtilityDefinitions()
+		utilDefs := []UtilityPod{}
+		err := viper.UnmarshalKey("utilityDefinitions", &utilDefs)
+		if err != nil {
+			logrus.Fatal("Error unmarshalling utility defs...")
+		}
+		if len(utilDefs) == 0 {
+			utilDefs = defaultUtilityDefinitions()
+		}
 
 		fmt.Printf("%-15s %-50s %s\n", "UTILITY", "REGISTRY", "EXEC_CMD")
 		fmt.Printf("%-15s %-50s %s\n", "---------------", "----------------------------------------------", "---------------------")

--- a/cmd/survey_functions.go
+++ b/cmd/survey_functions.go
@@ -43,11 +43,11 @@ type (
 	}
 )
 
-func askForUtility(utils map[string]UtilityPod) string {
+func askForUtility(utils []UtilityPod) string {
 
 	var utilArray []string
-	for k := range utils {
-		utilArray = append(utilArray, k)
+	for _, v := range utils {
+		utilArray = append(utilArray, v.Name)
 	}
 	sort.Strings(utilArray)
 
@@ -237,6 +237,9 @@ func askForNodeLabels(nodeList *v1.NodeList) string {
 	err := viper.UnmarshalKey("nodeSelectorLabels", &labelList)
 	if err != nil {
 		logrus.Fatal("Error unmarshalling...")
+	}
+	if len(labelList) == 0 {
+		labelList = defaultLabelList()
 	}
 	labelMap := make(map[string]string, len(labelList))
 	for _, v := range labelList {


### PR DESCRIPTION
## Description

Extend the functionality by moving the utility definitions into a config.yaml file that the end user can customize.

## Motivation and Context

## Dependencies

## How Has This Been Tested?

## Screenshots (if appropriate)

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [ ] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

### Additions

### Changes

- Utility Definitions defaults are written out to the `config.yaml` file if the key doesn't exist
- Utility Definitions are read from the `config.yaml`
- Simplified the `config.yaml` structure for the Utility Definitions

### Fixes

### Deprecated

### Removed

### Breaking Changes
