### PR TITLE
Migrate Outputs to a more standard method

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ jira readme
 
 ### Done
 
-- [x] KT-4:        Add a LIST for running PODs
-- [x] KT-5:        Add a LIST for defined container images
-- [x] KT-2:        Move container list details to config.yaml, create an initial version
+- [x] KT-4:    Add a LIST for running PODs
+- [x] KT-5:    Add a LIST for defined container images
+- [x] KT-2:    Move container list details to config.yaml, create an initial version
+- [x] KT-12:   Add a basic-tools image combining some of the others
+

--- a/cmd/default.go
+++ b/cmd/default.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"strings"
 
+	"ktrouble/objects"
 	"ktrouble/template"
 
 	"github.com/sirupsen/logrus"
@@ -22,11 +23,11 @@ type TemplateConfig struct {
 	Parameters map[string]string
 }
 
-type UtilityPod struct {
-	Name        string
-	Repository  string
-	ExecCommand string
-}
+// type UtilityPod struct {
+// 	Name        string
+// 	Repository  string
+// 	ExecCommand string
+// }
 
 var letters = []rune("abcdef0987654321")
 
@@ -37,7 +38,7 @@ var defaultCmd = &cobra.Command{
 	Long: `EXAMPLE:
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		utilDefs := []UtilityPod{}
+		utilDefs := []objects.UtilityPod{}
 		err := viper.UnmarshalKey("utilityDefinitions", &utilDefs)
 		if err != nil {
 			logrus.Fatal("Error unmarshalling utility defs...")
@@ -46,9 +47,9 @@ var defaultCmd = &cobra.Command{
 			utilDefs = defaultUtilityDefinitions()
 		}
 
-		utilMap := make(map[string]UtilityPod)
+		utilMap := make(map[string]objects.UtilityPod)
 		for _, v := range utilDefs {
-			utilMap[v.Name] = UtilityPod{
+			utilMap[v.Name] = objects.UtilityPod{
 				Name:        v.Name,
 				Repository:  v.Repository,
 				ExecCommand: v.ExecCommand,
@@ -148,9 +149,9 @@ func createPod(podJSON string, namespace string) {
 	// fmt.Printf("Created pod %q.\n", result.GetObjectMeta().GetName())
 }
 
-func defaultUtilityDefinitions() []UtilityPod {
+func defaultUtilityDefinitions() []objects.UtilityPod {
 
-	return []UtilityPod{
+	return []objects.UtilityPod{
 		{
 			Name:        "dnsutils",
 			Repository:  "gcr.io/kubernetes-e2e-test-images/dnsutils:1.3",

--- a/cmd/get_namespace.go
+++ b/cmd/get_namespace.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"ktrouble/objects"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -22,11 +24,17 @@ var namespaceCmd = &cobra.Command{
 
 		nssList := getNamespaces()
 
-		fmt.Println("NAMESPACE")
-		fmt.Println("---------------")
+		nsData := objects.NamespaceList{}
+		rawData := []string{}
 		for _, v := range nssList.Items {
-			fmt.Println(v.Name)
+			nsData.Namespace = append(nsData.Namespace, v.Name)
+			rawData = append(rawData, v.Name)
 		}
+
+		if !c.FormatOverridden {
+			c.OutputFormat = "text"
+		}
+		fmt.Println(namespaceDataToString(nsData, strings.Join(rawData, ",")))
 	},
 }
 
@@ -59,6 +67,24 @@ func getNamespaces() *v1.NamespaceList {
 	}
 	return nssList
 
+}
+
+func namespaceDataToString(nsData objects.NamespaceList, raw string) string {
+
+	switch strings.ToLower(c.OutputFormat) {
+	case "raw":
+		return raw
+	case "json":
+		return nsData.ToJSON()
+	case "gron":
+		return nsData.ToGRON()
+	case "yaml":
+		return nsData.ToYAML()
+	case "text", "table":
+		return nsData.ToTEXT(c.NoHeaders)
+	default:
+		return nsData.ToTEXT(c.NoHeaders)
+	}
 }
 
 func init() {

--- a/cmd/get_node.go
+++ b/cmd/get_node.go
@@ -3,6 +3,9 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"strings"
+
+	"ktrouble/objects"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -23,11 +26,18 @@ var nodeCmd = &cobra.Command{
 
 		nodeList := getNodes()
 
-		fmt.Println("NODES")
-		fmt.Println("---------------")
+		nodeData := objects.NodeList{}
+		rawData := []string{}
 		for _, v := range nodeList.Items {
-			fmt.Println(v.Name)
+			nodeData.Node = append(nodeData.Node, v.Name)
+			rawData = append(rawData, v.Name)
 		}
+
+		if !c.FormatOverridden {
+			c.OutputFormat = "text"
+		}
+		fmt.Println(nodeDataToString(nodeData, strings.Join(rawData, ",")))
+
 	},
 }
 
@@ -60,6 +70,24 @@ func getNodes() *v1.NodeList {
 	}
 	return nodeList
 
+}
+
+func nodeDataToString(nodeData objects.NodeList, raw string) string {
+
+	switch strings.ToLower(c.OutputFormat) {
+	case "raw":
+		return raw
+	case "json":
+		return nodeData.ToJSON()
+	case "gron":
+		return nodeData.ToGRON()
+	case "yaml":
+		return nodeData.ToYAML()
+	case "text", "table":
+		return nodeData.ToTEXT(c.NoHeaders)
+	default:
+		return nodeData.ToTEXT(c.NoHeaders)
+	}
 }
 
 func init() {

--- a/cmd/get_serviceaccount.go
+++ b/cmd/get_serviceaccount.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"ktrouble/objects"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -24,11 +26,17 @@ var serviceaccountCmd = &cobra.Command{
 
 		sasList := getServiceAccounts(namespace)
 
-		fmt.Println("SERVICE ACCOUNT")
-		fmt.Println("---------------")
+		saData := objects.ServiceAccountList{}
+		rawData := []string{}
 		for _, v := range sasList.Items {
-			fmt.Println(v.Name)
+			saData.ServiceAccount = append(saData.ServiceAccount, v.Name)
+			rawData = append(rawData, v.Name)
 		}
+
+		if !c.FormatOverridden {
+			c.OutputFormat = "text"
+		}
+		fmt.Println(saDataToString(saData, strings.Join(rawData, ",")))
 
 	},
 }
@@ -62,6 +70,24 @@ func getServiceAccounts(namespace string) *v1.ServiceAccountList {
 		return &v1.ServiceAccountList{}
 	}
 	return sasList
+}
+
+func saDataToString(saData objects.ServiceAccountList, raw string) string {
+
+	switch strings.ToLower(c.OutputFormat) {
+	case "raw":
+		return raw
+	case "json":
+		return saData.ToJSON()
+	case "gron":
+		return saData.ToGRON()
+	case "yaml":
+		return saData.ToYAML()
+	case "text", "table":
+		return saData.ToTEXT(c.NoHeaders)
+	default:
+		return saData.ToTEXT(c.NoHeaders)
+	}
 }
 
 func init() {

--- a/cmd/get_utilities.go
+++ b/cmd/get_utilities.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"ktrouble/objects"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -18,7 +20,7 @@ var utilitiesCmd = &cobra.Command{
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		utilDefs := []UtilityPod{}
+		utilDefs := []objects.UtilityPod{}
 		err := viper.UnmarshalKey("utilityDefinitions", &utilDefs)
 		if err != nil {
 			logrus.Fatal("Error unmarshalling utility defs...")
@@ -27,14 +29,31 @@ var utilitiesCmd = &cobra.Command{
 			utilDefs = defaultUtilityDefinitions()
 		}
 
-		fmt.Printf("%-15s %-50s %s\n", "UTILITY", "REGISTRY", "EXEC_CMD")
-		fmt.Printf("%-15s %-50s %s\n", "---------------", "----------------------------------------------", "---------------------")
-		for _, v := range utilDefs {
-			fmt.Printf("%-15s %-50s %s\n", v.Name, v.Repository, v.ExecCommand)
+		if !c.FormatOverridden {
+			c.OutputFormat = "text"
 		}
+		fmt.Println(utilityPodDataToString(utilDefs, fmt.Sprintf("%#v", utilDefs)))
+
 	},
 }
 
+func utilityPodDataToString(podData objects.UtilityPodList, raw string) string {
+
+	switch strings.ToLower(c.OutputFormat) {
+	case "raw":
+		return raw
+	case "json":
+		return podData.ToJSON()
+	case "gron":
+		return podData.ToGRON()
+	case "yaml":
+		return podData.ToYAML()
+	case "text", "table":
+		return podData.ToTEXT(c.NoHeaders)
+	default:
+		return podData.ToTEXT(c.NoHeaders)
+	}
+}
 func init() {
 	getCmd.AddCommand(utilitiesCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 
 	"ktrouble/common"
 	"ktrouble/config"
+	"ktrouble/objects"
 
 	homedir "github.com/mitchellh/go-homedir"
 	"k8s.io/client-go/rest"
@@ -153,7 +154,7 @@ func initConfig() {
 	if err := viper.ReadInConfig(); err != nil {
 		logrus.Warn("Failed to read viper config file.")
 	}
-	utilDefs := []UtilityPod{}
+	utilDefs := []objects.UtilityPod{}
 	err := viper.UnmarshalKey("utilityDefinitions", &utilDefs)
 	if err != nil {
 		logrus.Fatal("Error unmarshalling utility defs...")

--- a/cmd/survey_functions.go
+++ b/cmd/survey_functions.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"sort"
 
+	"ktrouble/objects"
+
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -43,7 +45,7 @@ type (
 	}
 )
 
-func askForUtility(utils []UtilityPod) string {
+func askForUtility(utils []objects.UtilityPod) string {
 
 	var utilArray []string
 	for _, v := range utils {
@@ -82,7 +84,7 @@ func askForNamespace(nssList *v1.NamespaceList) string {
 		{
 			Name: "namespace",
 			Prompt: &survey.Select{
-				Message: "Choose a namespace to create the pod in:",
+				Message: "Choose a namespace:",
 				Options: nsArray,
 			},
 		},

--- a/objects/namespace.go
+++ b/objects/namespace.go
@@ -1,0 +1,84 @@
+package objects
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	"github.com/maahsome/gron"
+	"github.com/olekukonko/tablewriter"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+)
+
+type NamespaceList struct {
+	Namespace []string `json:"namespace"`
+}
+
+// ToJSON - Write the output as JSON
+func (n *NamespaceList) ToJSON() string {
+	nsJSON, err := json.MarshalIndent(n, "", "  ")
+	if err != nil {
+		logrus.WithError(err).Error("Error extracting JSON")
+		return ""
+	}
+	return string(nsJSON[:])
+}
+
+func (n *NamespaceList) ToGRON() string {
+	nsJSON, err := json.MarshalIndent(n, "", "  ")
+	if err != nil {
+		logrus.WithError(err).Error("Error extracting JSON for GRON")
+	}
+	subReader := strings.NewReader(string(nsJSON[:]))
+	subValues := &bytes.Buffer{}
+	ges := gron.NewGron(subReader, subValues)
+	ges.SetMonochrome(false)
+	if serr := ges.ToGron(); serr != nil {
+		logrus.WithError(serr).Error("Problem generating GRON syntax")
+		return ""
+	}
+	return subValues.String()
+}
+
+func (n *NamespaceList) ToYAML() string {
+	nsYAML, err := yaml.Marshal(n)
+	if err != nil {
+		logrus.WithError(err).Error("Error extracting YAML")
+		return ""
+	}
+	return string(nsYAML[:])
+}
+
+func (n *NamespaceList) ToTEXT(noHeaders bool) string {
+	buf := new(bytes.Buffer)
+	var row []string
+
+	// ************************** TableWriter ******************************
+	table := tablewriter.NewWriter(buf)
+	if !noHeaders {
+		table.SetHeader([]string{"NAMESPACE"})
+		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	}
+
+	table.SetAutoWrapText(false)
+	table.SetAutoFormatHeaders(true)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetTablePadding("\t") // pad with tabs
+	table.SetNoWhiteSpace(true)
+
+	for _, v := range n.Namespace {
+		row = []string{
+			v,
+		}
+		table.Append(row)
+	}
+	table.Render()
+
+	return buf.String()
+}

--- a/objects/node.go
+++ b/objects/node.go
@@ -1,0 +1,84 @@
+package objects
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	"github.com/maahsome/gron"
+	"github.com/olekukonko/tablewriter"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+)
+
+type NodeList struct {
+	Node []string `json:"node"`
+}
+
+// ToJSON - Write the output as JSON
+func (n *NodeList) ToJSON() string {
+	nJSON, err := json.MarshalIndent(n, "", "  ")
+	if err != nil {
+		logrus.WithError(err).Error("Error extracting JSON")
+		return ""
+	}
+	return string(nJSON[:])
+}
+
+func (n *NodeList) ToGRON() string {
+	nJSON, err := json.MarshalIndent(n, "", "  ")
+	if err != nil {
+		logrus.WithError(err).Error("Error extracting JSON for GRON")
+	}
+	subReader := strings.NewReader(string(nJSON[:]))
+	subValues := &bytes.Buffer{}
+	ges := gron.NewGron(subReader, subValues)
+	ges.SetMonochrome(false)
+	if serr := ges.ToGron(); serr != nil {
+		logrus.WithError(serr).Error("Problem generating GRON syntax")
+		return ""
+	}
+	return subValues.String()
+}
+
+func (n *NodeList) ToYAML() string {
+	nYAML, err := yaml.Marshal(n)
+	if err != nil {
+		logrus.WithError(err).Error("Error extracting YAML")
+		return ""
+	}
+	return string(nYAML[:])
+}
+
+func (n *NodeList) ToTEXT(noHeaders bool) string {
+	buf := new(bytes.Buffer)
+	var row []string
+
+	// ************************** TableWriter ******************************
+	table := tablewriter.NewWriter(buf)
+	if !noHeaders {
+		table.SetHeader([]string{"NODE"})
+		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	}
+
+	table.SetAutoWrapText(false)
+	table.SetAutoFormatHeaders(true)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetTablePadding("\t") // pad with tabs
+	table.SetNoWhiteSpace(true)
+
+	for _, v := range n.Node {
+		row = []string{
+			v,
+		}
+		table.Append(row)
+	}
+	table.Render()
+
+	return buf.String()
+}

--- a/objects/pod.go
+++ b/objects/pod.go
@@ -1,0 +1,92 @@
+package objects
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	"github.com/maahsome/gron"
+	"github.com/olekukonko/tablewriter"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+)
+
+type PodList []Pod
+
+type Pod struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Status    string `json:"status"`
+}
+
+// ToJSON - Write the output as JSON
+func (p *PodList) ToJSON() string {
+	podJSON, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		logrus.WithError(err).Error("Error extracting JSON")
+		return ""
+	}
+	return string(podJSON[:])
+}
+
+func (p *PodList) ToGRON() string {
+	podJSON, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		logrus.WithError(err).Error("Error extracting JSON for GRON")
+	}
+	subReader := strings.NewReader(string(podJSON[:]))
+	subValues := &bytes.Buffer{}
+	ges := gron.NewGron(subReader, subValues)
+	ges.SetMonochrome(false)
+	if serr := ges.ToGron(); serr != nil {
+		logrus.WithError(serr).Error("Problem generating GRON syntax")
+		return ""
+	}
+	return string(subValues.Bytes())
+}
+
+func (p *PodList) ToYAML() string {
+	podYAML, err := yaml.Marshal(p)
+	if err != nil {
+		logrus.WithError(err).Error("Error extracting YAML")
+		return ""
+	}
+	return string(podYAML[:])
+}
+
+func (p *PodList) ToTEXT(noHeaders bool) string {
+	buf, row := new(bytes.Buffer), make([]string, 0)
+
+	// ************************** TableWriter ******************************
+	table := tablewriter.NewWriter(buf)
+	if !noHeaders {
+		headerText := []string{"NAME", "NAMESPACE", "STATUS"}
+		table.SetHeader(headerText)
+		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	}
+
+	table.SetAutoWrapText(false)
+	table.SetAutoFormatHeaders(true)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetTablePadding("\t") // pad with tabs
+	table.SetNoWhiteSpace(true)
+
+	for _, v := range *p {
+		row = []string{
+			v.Name,
+			v.Namespace,
+			v.Status,
+		}
+		table.Append(row)
+	}
+
+	table.Render()
+
+	return buf.String()
+
+}

--- a/objects/serviceaccount.go
+++ b/objects/serviceaccount.go
@@ -1,0 +1,84 @@
+package objects
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	"github.com/maahsome/gron"
+	"github.com/olekukonko/tablewriter"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+)
+
+type ServiceAccountList struct {
+	ServiceAccount []string `json:"serviceAccount"`
+}
+
+// ToJSON - Write the output as JSON
+func (sa *ServiceAccountList) ToJSON() string {
+	saJSON, err := json.MarshalIndent(sa, "", "  ")
+	if err != nil {
+		logrus.WithError(err).Error("Error extracting JSON")
+		return ""
+	}
+	return string(saJSON[:])
+}
+
+func (sa *ServiceAccountList) ToGRON() string {
+	saJSON, err := json.MarshalIndent(sa, "", "  ")
+	if err != nil {
+		logrus.WithError(err).Error("Error extracting JSON for GRON")
+	}
+	subReader := strings.NewReader(string(saJSON[:]))
+	subValues := &bytes.Buffer{}
+	ges := gron.NewGron(subReader, subValues)
+	ges.SetMonochrome(false)
+	if serr := ges.ToGron(); serr != nil {
+		logrus.WithError(serr).Error("Problem generating GRON syntax")
+		return ""
+	}
+	return subValues.String()
+}
+
+func (sa *ServiceAccountList) ToYAML() string {
+	saYAML, err := yaml.Marshal(sa)
+	if err != nil {
+		logrus.WithError(err).Error("Error extracting YAML")
+		return ""
+	}
+	return string(saYAML[:])
+}
+
+func (sa *ServiceAccountList) ToTEXT(noHeaders bool) string {
+	buf := new(bytes.Buffer)
+	var row []string
+
+	// ************************** TableWriter ******************************
+	table := tablewriter.NewWriter(buf)
+	if !noHeaders {
+		table.SetHeader([]string{"SERVICEACCOUNT"})
+		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	}
+
+	table.SetAutoWrapText(false)
+	table.SetAutoFormatHeaders(true)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetTablePadding("\t") // pad with tabs
+	table.SetNoWhiteSpace(true)
+
+	for _, v := range sa.ServiceAccount {
+		row = []string{
+			v,
+		}
+		table.Append(row)
+	}
+	table.Render()
+
+	return buf.String()
+}

--- a/objects/utility.go
+++ b/objects/utility.go
@@ -1,0 +1,103 @@
+package objects
+
+import (
+	"bytes"
+	"encoding/json"
+	"sort"
+	"strings"
+
+	"github.com/maahsome/gron"
+	"github.com/olekukonko/tablewriter"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+)
+
+type UtilityPodList []UtilityPod
+
+type UtilityPod struct {
+	Name        string `json:"name"`
+	Repository  string `json:"repository"`
+	ExecCommand string `json:"execcommand"`
+}
+
+// ToJSON - Write the output as JSON
+func (up *UtilityPodList) ToJSON() string {
+	podJSON, err := json.MarshalIndent(up, "", "  ")
+	if err != nil {
+		logrus.WithError(err).Error("Error extracting JSON")
+		return ""
+	}
+	return string(podJSON[:])
+}
+
+func (up *UtilityPodList) ToGRON() string {
+	podJSON, err := json.MarshalIndent(up, "", "  ")
+	if err != nil {
+		logrus.WithError(err).Error("Error extracting JSON for GRON")
+	}
+	subReader := strings.NewReader(string(podJSON[:]))
+	subValues := &bytes.Buffer{}
+	ges := gron.NewGron(subReader, subValues)
+	ges.SetMonochrome(false)
+	if serr := ges.ToGron(); serr != nil {
+		logrus.WithError(serr).Error("Problem generating GRON syntax")
+		return ""
+	}
+	return string(subValues.Bytes())
+}
+
+func (up *UtilityPodList) ToYAML() string {
+	podYAML, err := yaml.Marshal(up)
+	if err != nil {
+		logrus.WithError(err).Error("Error extracting YAML")
+		return ""
+	}
+	return string(podYAML[:])
+}
+
+func (up *UtilityPodList) ToTEXT(noHeaders bool) string {
+	buf, row := new(bytes.Buffer), make([]string, 0)
+
+	// ************************** TableWriter ******************************
+	table := tablewriter.NewWriter(buf)
+	if !noHeaders {
+		headerText := []string{"NAME", "REPOSITORY", "EXEC"}
+		table.SetHeader(headerText)
+		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	}
+
+	table.SetAutoWrapText(false)
+	table.SetAutoFormatHeaders(true)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetTablePadding("\t") // pad with tabs
+	table.SetNoWhiteSpace(true)
+
+	mapList := make(map[string]UtilityPod, len(*up))
+	nameList := []string{}
+
+	for _, v := range *up {
+		mapList[v.Name] = v
+		nameList = append(nameList, v.Name)
+	}
+
+	sort.Strings(nameList)
+
+	for _, v := range nameList {
+		row = []string{
+			mapList[v].Name,
+			mapList[v].Repository,
+			mapList[v].ExecCommand,
+		}
+		table.Append(row)
+	}
+
+	table.Render()
+
+	return buf.String()
+
+}


### PR DESCRIPTION
## Description

Adding `-o <json|yaml|gron|text|raw>` as output options for all of the `get` commands:

- utilities
- pods
- namespaces
- serviceaccounts
- node

## Motivation and Context

Make the output more consumable

## Dependencies

## How Has This Been Tested?

Just some manual running of commands... 

## Screenshots (if appropriate)

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [ ] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
- **BREAKING** note on base feature
- Basically whatever formatting we have here, just plain-text
%> command example
- next feature
- note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

### Changes

- Moved the UtilityPod struct to `objects`
- Standardized the `get` commands to use `-o` to set the output type
- Output formats supported: json, yaml, gron, text, raw

### Fixes

### Deprecated

### Removed

### Breaking Changes
