### PR TITLE
Move the utilDefs variable to a global, only need to load it at init

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,6 @@ A CLI tool for launching troubleshooting docker images into a kubernetes cluster
 brew install maahsome/tap/ktrouble --formula
 ```
 
-## TODO
-
-- [ ] Validate the name of the utility container?
-- [x] Display a list of choices of utility container if NO args[0] is passed in
-- [x] Display a list of choices of K8s ServiceAccounts if no args[1] is passed in
-- [x] Provide a switch to directly submit the manifest to the KUBECONFIG defined current context
-  - this is just default, no switch
-- [x] Add a deeper definition for utility containers, specifying sizes (requests/limits)
-- Add a check to see if the POD has already been created
-- [x] Add a "delete" container command
-- [ ] Add a config.yaml based list of container details
-
 ## PERSONAL JIRA LIST
 
 ```zsh
@@ -31,7 +19,6 @@ jira readme
 
 - [ ] KT-1:    Add EXAMPLES and Documentation 
 - [ ] KT-3:    Find and add an ansible container 
-- [ ] KT-6:    Convert to real OUTPUT formats 
 - [ ] KT-7:    Replace logrus with common.Logger 
 - [ ] KT-8:    In the delete command, when no pods are running, exit with that description 
 - [ ] KT-9:    Extend the delete command to look at the first param after delete and use that as the delete POD name 
@@ -40,8 +27,9 @@ jira readme
 
 ### Done
 
-- [x] KT-4:    Add a LIST for running PODs
-- [x] KT-5:    Add a LIST for defined container images
-- [x] KT-2:    Move container list details to config.yaml, create an initial version
-- [x] KT-12:   Add a basic-tools image combining some of the others
+- [x] KT-4:    Add a LIST for running PODs 
+- [x] KT-5:    Add a LIST for defined container images 
+- [x] KT-2:    Move container list details to config.yaml, create an initial version 
+- [x] KT-12:   Add a basic-tools image combining some of the others 
+- [x] KT-6:    Convert to real OUTPUT formats 
 

--- a/cmd/default.go
+++ b/cmd/default.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sYaml "k8s.io/apimachinery/pkg/util/yaml"
@@ -38,14 +37,6 @@ var defaultCmd = &cobra.Command{
 	Long: `EXAMPLE:
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		utilDefs := []objects.UtilityPod{}
-		err := viper.UnmarshalKey("utilityDefinitions", &utilDefs)
-		if err != nil {
-			logrus.Fatal("Error unmarshalling utility defs...")
-		}
-		if len(utilDefs) == 0 {
-			utilDefs = defaultUtilityDefinitions()
-		}
 
 		utilMap := make(map[string]objects.UtilityPod)
 		for _, v := range utilDefs {

--- a/cmd/get_utilities.go
+++ b/cmd/get_utilities.go
@@ -5,9 +5,7 @@ import (
 	"ktrouble/objects"
 	"strings"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // utilitiesCmd represents the namespace command
@@ -19,15 +17,6 @@ var utilitiesCmd = &cobra.Command{
 	> ktrouble get utilities
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-
-		utilDefs := []objects.UtilityPod{}
-		err := viper.UnmarshalKey("utilityDefinitions", &utilDefs)
-		if err != nil {
-			logrus.Fatal("Error unmarshalling utility defs...")
-		}
-		if len(utilDefs) == 0 {
-			utilDefs = defaultUtilityDefinitions()
-		}
 
 		if !c.FormatOverridden {
 			c.OutputFormat = "text"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,7 +38,8 @@ var (
 	gitRef    string
 	buildDate string
 
-	c = &config.Config{}
+	c        = &config.Config{}
+	utilDefs []objects.UtilityPod
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -154,7 +155,6 @@ func initConfig() {
 	if err := viper.ReadInConfig(); err != nil {
 		logrus.Warn("Failed to read viper config file.")
 	}
-	utilDefs := []objects.UtilityPod{}
 	err := viper.UnmarshalKey("utilityDefinitions", &utilDefs)
 	if err != nil {
 		logrus.Fatal("Error unmarshalling utility defs...")


### PR DESCRIPTION
## Description

Just make the consumption of the utility definitions from the config.yaml easier to consume in the code.

## Motivation and Context

## Dependencies

## How Has This Been Tested?

## Screenshots (if appropriate)

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [ ] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

### Additions

### Changes

- No functional changes, just code refactor.  
- Moved the utilDefs variable to a global, and only load it during init

### Fixes

### Deprecated

### Removed

### Breaking Changes

