### PR TITLE
Adding iterm2 smart select support on <bash:>

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ jira readme
 
 - [ ] KT-1:    Add EXAMPLES and Documentation 
 - [ ] KT-3:    Find and add an ansible container 
-- [ ] KT-7:    Replace logrus with common.Logger 
 - [ ] KT-8:    In the delete command, when no pods are running, exit with that description 
 - [ ] KT-9:    Extend the delete command to look at the first param after delete and use that as the delete POD name 
 - [ ] KT-10:   Fix a bug where the utilitydefinitions are detected as empty, and defaults are written to config.yaml 
@@ -32,4 +31,5 @@ jira readme
 - [x] KT-12:   Add a basic-tools image combining some of the others 
 - [x] KT-6:    Convert to real OUTPUT formats 
 - [x] KT-11:   Read the utilitydefinitions into a global variable rather than re-read config all the time (both MAP and ARRAY) 
+- [x] KT-7:    Replace logrus with common.Logger 
 

--- a/cmd/default.go
+++ b/cmd/default.go
@@ -64,7 +64,7 @@ var defaultCmd = &cobra.Command{
 		if selector == "\"-none-\"" {
 			hasSelector = "false"
 		}
-		shortUniq := randSeq(6)
+		shortUniq := randSeq(uniqIdLength)
 		tc := &TemplateConfig{
 			Parameters: map[string]string{
 				"name":           fmt.Sprintf("%s-%s", utility, shortUniq),

--- a/cmd/get_running.go
+++ b/cmd/get_running.go
@@ -53,9 +53,9 @@ func podDataToString(podData objects.PodList, raw string) string {
 	case "yaml":
 		return podData.ToYAML()
 	case "text", "table":
-		return podData.ToTEXT(c.NoHeaders)
+		return podData.ToTEXT(c.NoHeaders, c.EnableBashLinks, utilMap, uniqIdLength)
 	default:
-		return podData.ToTEXT(c.NoHeaders)
+		return podData.ToTEXT(c.NoHeaders, c.EnableBashLinks, utilMap, uniqIdLength)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,10 @@ import (
 	// "sigs.k8s.io/yaml"
 )
 
+const (
+	uniqIdLength = 6
+)
+
 type (
 	Project struct {
 		ID     int    `json:"id"`
@@ -39,6 +43,7 @@ var (
 	buildDate string
 
 	c        = &config.Config{}
+	utilMap  map[string]objects.UtilityPod
 	utilDefs []objects.UtilityPod
 )
 
@@ -81,6 +86,7 @@ var rootCmd = &cobra.Command{
 		c.VersionDetail.BuildDate = buildDate
 		c.VersionDetail.GitCommit = gitCommit
 		c.VersionDetail.GitRef = gitRef
+		c.EnableBashLinks = viper.GetBool("enableBashLinks")
 		c.VersionJSON = fmt.Sprintf("{\"SemVer\": \"%s\", \"BuildDate\": \"%s\", \"GitCommit\": \"%s\", \"GitRef\": \"%s\"}", semVer, buildDate, gitCommit, gitRef)
 		if c.OutputFormat != "" {
 			c.FormatOverridden = true
@@ -160,6 +166,11 @@ func initConfig() {
 		verr := viper.WriteConfig()
 		if verr != nil {
 			logrus.WithError(verr).Info("Failed to write config")
+		}
+	} else {
+		utilMap = make(map[string]objects.UtilityPod, len(utilDefs))
+		for _, v := range utilDefs {
+			utilMap[v.Name] = v
 		}
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ type (
 		CACert           string
 		CABundle         string
 		Namespace        string
+		EnableBashLinks  bool
 	}
 	Outputtable interface {
 		ToJSON() string


### PR DESCRIPTION
## Description

Using iterm2 and configuring Smart Selection, we can create clickable `<bash:your command here>` links that will then appear at your command line when clicked.  

## Motivation and Context

Just a nice shortcut to the `kubectl exec` command.

## Dependencies

## How Has This Been Tested?

## Screenshots (if appropriate)

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [ ] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
- **BREAKING** note on base feature
- Basically whatever formatting we have here, just plain-text
%> command example
- next feature
- note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

- Adding code to output an EXEC field that contains a `<bash:>` style link.
- These links can be configured for iTerm2 using Smart Selection Rules
- The links are enabled with a `enablebashlinks: true` in the `config.yaml`
- The definition in the iTerm2 profile looks like this:

```json
"Smart Selection Rules" : [
        {
          "notes" : "CMD URL",
          "precision" : "very_low",
          "regex" : "<bash:(.*)>",
          "actions" : [
            {
              "title" : "Run Command",
              "action" : 4,
              "parameter" : "\\\\1"
            }
          ]
        }
      ]
```

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes
