### PR TITLE
Move sizing definitions to config.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,6 @@ jira readme
 - [x] KT-6:    Convert to real OUTPUT formats 
 - [x] KT-11:   Read the utilitydefinitions into a global variable rather than re-read config all the time (both MAP and ARRAY) 
 - [x] KT-7:    Replace logrus with common.Logger 
-- [x] KT-13:   Add a bash:// column to the get pods output
+- [x] KT-13:   Add a bash:// column to the get pods output 
+- [x] KT-14:   Add get sizes to display the request/limits for each size 
 

--- a/cmd/default.go
+++ b/cmd/default.go
@@ -71,10 +71,10 @@ var defaultCmd = &cobra.Command{
 				"serviceAccount": sa,
 				"namespace":      namespace,
 				"registry":       utilMap[utility].Repository,
-				"limitsCpu":      resourceSize["limitsCpu"],
-				"limitsMem":      resourceSize["limitsMem"],
-				"requestCpu":     resourceSize["requestCpu"],
-				"requestMem":     resourceSize["requestMem"],
+				"limitsCpu":      sizeMap[resourceSize].LimitsCPU,
+				"limitsMem":      sizeMap[resourceSize].LimitsMEM,
+				"requestCpu":     sizeMap[resourceSize].RequestCPU,
+				"requestMem":     sizeMap[resourceSize].RequestMEM,
 				"hasSelector":    hasSelector,
 				"selector":       selector,
 			},
@@ -128,73 +128,6 @@ func createPod(podJSON string, namespace string) {
 		common.Logger.WithError(cerr).Fatal("Failed to create pod")
 	}
 	// fmt.Printf("Created pod %q.\n", result.GetObjectMeta().GetName())
-}
-
-func defaultUtilityDefinitions() []objects.UtilityPod {
-
-	return []objects.UtilityPod{
-		{
-			Name:        "dnsutils",
-			Repository:  "gcr.io/kubernetes-e2e-test-images/dnsutils:1.3",
-			ExecCommand: "/bin/sh",
-		},
-		{
-			Name:        "psql-curl",
-			Repository:  "barrypiccinni/psql-curl:latest",
-			ExecCommand: "/bin/bash",
-		},
-		{
-			Name:        "psqlutils15",
-			Repository:  "postgres:15-bullseye",
-			ExecCommand: "/bin/bash",
-		},
-		{
-			Name:        "psqlutils14",
-			Repository:  "postgres:14-bullseye",
-			ExecCommand: "/bin/bash",
-		},
-		{
-			Name:        "awscli",
-			Repository:  "amazon/aws-cli:latest",
-			ExecCommand: "/bin/bash",
-		},
-		{
-			Name:        "gcloudutils",
-			Repository:  "google/cloud-sdk:latest",
-			ExecCommand: "/bin/bash",
-		},
-		{
-			Name:        "azutils",
-			Repository:  "mcr.microsoft.com/azure-cli",
-			ExecCommand: "/bin/bash",
-		},
-		{
-			Name:        "mysqlutils5",
-			Repository:  "mysql:5.7.40-debian",
-			ExecCommand: "/bin/bash",
-		},
-		{
-			Name:        "mysqlutils8",
-			Repository:  "mysql:8-debian",
-			ExecCommand: "/bin/bash",
-		},
-		{
-			Name:        "redis6",
-			Repository:  "cmaahs/redis-cli:6.2",
-			ExecCommand: "/bin/bash",
-		},
-		{
-			Name:        "curl",
-			Repository:  "curlimages/curl:latest",
-			ExecCommand: "/bin/sh",
-		},
-		{
-			Name:        "basic-tools",
-			Repository:  "cmaahs/basic-tools:v0.0.1",
-			ExecCommand: "/bin/bash",
-		},
-	}
-
 }
 
 func init() {

--- a/cmd/get_sizes.go
+++ b/cmd/get_sizes.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"fmt"
+	"ktrouble/objects"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// sizesCmd represents the namespace command
+var sizesCmd = &cobra.Command{
+	Use:     "sizes",
+	Aliases: []string{"size", "requests", "request", "limit", "limits"},
+	Short:   "Get a list of defined sizes",
+	Long: `EXAMPLE:
+	> ktrouble get sizes
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		if !c.FormatOverridden {
+			c.OutputFormat = "text"
+		}
+		fmt.Println(sizeDataToString(sizeDefs, fmt.Sprintf("%#v", sizeDefs)))
+
+	},
+}
+
+func sizeDataToString(sizeData objects.ResourceSizeList, raw string) string {
+
+	switch strings.ToLower(c.OutputFormat) {
+	case "raw":
+		return raw
+	case "json":
+		return sizeData.ToJSON()
+	case "gron":
+		return sizeData.ToGRON()
+	case "yaml":
+		return sizeData.ToYAML()
+	case "text", "table":
+		return sizeData.ToTEXT(c.NoHeaders)
+	default:
+		return sizeData.ToTEXT(c.NoHeaders)
+	}
+}
+func init() {
+	getCmd.AddCommand(sizesCmd)
+}

--- a/cmd/survey_functions.go
+++ b/cmd/survey_functions.go
@@ -126,13 +126,12 @@ func askForServiceAccount(sasList *v1.ServiceAccountList) string {
 	return saAnswer.ServiceAccount
 }
 
-func askForResourceSize() map[string]string {
+func askForResourceSize() string {
 
-	rsArray := []string{
-		"Small",
-		"Medium",
-		"Large",
-		"XLarge",
+	rsArray := []string{}
+
+	for _, v := range sizeDefs {
+		rsArray = append(rsArray, v.Name)
 	}
 
 	var rsSurvey = []*survey.Question{
@@ -152,43 +151,7 @@ func askForResourceSize() map[string]string {
 		common.Logger.WithError(err).Fatal("No resource size selected")
 	}
 
-	switch rsAnswer.ResourceSize {
-	case "Small":
-		return map[string]string{
-			"limitsCpu":  "250m",
-			"limitsMem":  "2Gi",
-			"requestCpu": "100m",
-			"requestMem": "512Mi",
-		}
-	case "Medium":
-		return map[string]string{
-			"limitsCpu":  "500m",
-			"limitsMem":  "4Gi",
-			"requestCpu": "200m",
-			"requestMem": "1Gi",
-		}
-	case "Large":
-		return map[string]string{
-			"limitsCpu":  "1000m",
-			"limitsMem":  "8Gi",
-			"requestCpu": "500m",
-			"requestMem": "2Gi",
-		}
-	case "XLarge":
-		return map[string]string{
-			"limitsCpu":  "10000m",
-			"limitsMem":  "30Gi",
-			"requestCpu": "6000m",
-			"requestMem": "2Gi",
-		}
-	}
-
-	return map[string]string{
-		"limitsCpu":  "250m",
-		"limitsMem":  "2Gi",
-		"requestCpu": "100m",
-		"requestMem": "512Mi",
-	}
+	return rsAnswer.ResourceSize
 }
 
 func askForPod(podList *v1.PodList) PodDetail {

--- a/main.go
+++ b/main.go
@@ -28,12 +28,4 @@ func setDefaultCommandIfNonePresent() {
 func main() {
 	setDefaultCommandIfNonePresent()
 	cmd.Execute()
-	// if err := cmd.Execute(); err != nil {
-	// 	logrus.WithError(err).Error("Error executing command")
-	// 	os.Exit(1)
-	// }
 }
-
-// func main() {
-// 	cmd.Execute()
-// }

--- a/objects/size.go
+++ b/objects/size.go
@@ -1,0 +1,105 @@
+package objects
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	"ktrouble/common"
+
+	"github.com/maahsome/gron"
+	"github.com/olekukonko/tablewriter"
+	"gopkg.in/yaml.v2"
+)
+
+type ResourceSizeList []ResourceSize
+
+type ResourceSize struct {
+	Name       string `json:"name"`
+	LimitsCPU  string `json:"limitsCpu"`
+	LimitsMEM  string `json:"limitsMem"`
+	RequestCPU string `json:"requestCpu"`
+	RequestMEM string `json:"requestMem"`
+}
+
+// ToJSON - Write the output as JSON
+func (rs *ResourceSizeList) ToJSON() string {
+	rsJSON, err := json.MarshalIndent(rs, "", "  ")
+	if err != nil {
+		common.Logger.WithError(err).Error("Error extracting JSON")
+		return ""
+	}
+	return string(rsJSON[:])
+}
+
+func (rs *ResourceSizeList) ToGRON() string {
+	rsJSON, err := json.MarshalIndent(rs, "", "  ")
+	if err != nil {
+		common.Logger.WithError(err).Error("Error extracting JSON for GRON")
+	}
+	subReader := strings.NewReader(string(rsJSON[:]))
+	subValues := &bytes.Buffer{}
+	ges := gron.NewGron(subReader, subValues)
+	ges.SetMonochrome(false)
+	if serr := ges.ToGron(); serr != nil {
+		common.Logger.WithError(serr).Error("Problem generating GRON syntax")
+		return ""
+	}
+	return string(subValues.Bytes())
+}
+
+func (rs *ResourceSizeList) ToYAML() string {
+	rsYAML, err := yaml.Marshal(rs)
+	if err != nil {
+		common.Logger.WithError(err).Error("Error extracting YAML")
+		return ""
+	}
+	return string(rsYAML[:])
+}
+
+func (rs *ResourceSizeList) ToTEXT(noHeaders bool) string {
+	buf, row := new(bytes.Buffer), make([]string, 0)
+
+	// ************************** TableWriter ******************************
+	table := tablewriter.NewWriter(buf)
+	if !noHeaders {
+		headerText := []string{"NAME", "CPULIMIT", "MEMLIMIT", "CPUREQUEST", "MEMREQUEST"}
+		table.SetHeader(headerText)
+		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	}
+
+	table.SetAutoWrapText(false)
+	table.SetAutoFormatHeaders(true)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetTablePadding("\t") // pad with tabs
+	table.SetNoWhiteSpace(true)
+
+	mapList := make(map[string]ResourceSize, len(*rs))
+	nameList := []string{}
+
+	for _, v := range *rs {
+		mapList[v.Name] = v
+		nameList = append(nameList, v.Name)
+	}
+
+	for _, v := range nameList {
+		row = []string{
+			mapList[v].Name,
+			mapList[v].LimitsCPU,
+			mapList[v].LimitsMEM,
+			mapList[v].RequestCPU,
+			mapList[v].RequestMEM,
+		}
+		table.Append(row)
+	}
+
+	table.Render()
+
+	return buf.String()
+
+}


### PR DESCRIPTION
## Description

Move the hard-coded sizing information into the config.yaml file.

## Motivation and Context

## Dependencies

## How Has This Been Tested?

## Screenshots (if appropriate)

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [ ] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
- **BREAKING** note on base feature
- Basically whatever formatting we have here, just plain-text
%> command example
- next feature
- note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

- Add a `get sizes` command to list the current sizing settings

### Changes

- Move the sizing information to the `config.yaml` file

### Fixes

### Deprecated

### Removed

### Breaking Changes
