### PR TITLE
Make header names be able to use _ character

### DIFF
--- a/objects/namespace.go
+++ b/objects/namespace.go
@@ -63,7 +63,7 @@ func (n *NamespaceList) ToTEXT(noHeaders bool) string {
 	}
 
 	table.SetAutoWrapText(false)
-	table.SetAutoFormatHeaders(true)
+	table.SetAutoFormatHeaders(false)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetCenterSeparator("")
 	table.SetColumnSeparator("")

--- a/objects/node.go
+++ b/objects/node.go
@@ -63,7 +63,7 @@ func (n *NodeList) ToTEXT(noHeaders bool) string {
 	}
 
 	table.SetAutoWrapText(false)
-	table.SetAutoFormatHeaders(true)
+	table.SetAutoFormatHeaders(false)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetCenterSeparator("")
 	table.SetColumnSeparator("")

--- a/objects/pod.go
+++ b/objects/pod.go
@@ -71,7 +71,7 @@ func (p *PodList) ToTEXT(noHeaders bool, showExec bool, utilMap map[string]Utili
 	}
 
 	table.SetAutoWrapText(false)
-	table.SetAutoFormatHeaders(true)
+	table.SetAutoFormatHeaders(false)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetCenterSeparator("")
 	table.SetColumnSeparator("")

--- a/objects/serviceaccount.go
+++ b/objects/serviceaccount.go
@@ -58,12 +58,12 @@ func (sa *ServiceAccountList) ToTEXT(noHeaders bool) string {
 	// ************************** TableWriter ******************************
 	table := tablewriter.NewWriter(buf)
 	if !noHeaders {
-		table.SetHeader([]string{"SERVICEACCOUNT"})
+		table.SetHeader([]string{"SERVICE_ACCOUNT"})
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	}
 
 	table.SetAutoWrapText(false)
-	table.SetAutoFormatHeaders(true)
+	table.SetAutoFormatHeaders(false)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetCenterSeparator("")
 	table.SetColumnSeparator("")

--- a/objects/size.go
+++ b/objects/size.go
@@ -63,13 +63,13 @@ func (rs *ResourceSizeList) ToTEXT(noHeaders bool) string {
 	// ************************** TableWriter ******************************
 	table := tablewriter.NewWriter(buf)
 	if !noHeaders {
-		headerText := []string{"NAME", "CPULIMIT", "MEMLIMIT", "CPUREQUEST", "MEMREQUEST"}
+		headerText := []string{"NAME", "CPU_LIMIT", "MEM_LIMIT", "CPU_REQUEST", "MEM_REQUEST"}
 		table.SetHeader(headerText)
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	}
 
 	table.SetAutoWrapText(false)
-	table.SetAutoFormatHeaders(true)
+	table.SetAutoFormatHeaders(false)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetCenterSeparator("")
 	table.SetColumnSeparator("")

--- a/objects/utility.go
+++ b/objects/utility.go
@@ -68,7 +68,7 @@ func (up *UtilityPodList) ToTEXT(noHeaders bool) string {
 	}
 
 	table.SetAutoWrapText(false)
-	table.SetAutoFormatHeaders(true)
+	table.SetAutoFormatHeaders(false)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetCenterSeparator("")
 	table.SetColumnSeparator("")

--- a/objects/version.go
+++ b/objects/version.go
@@ -66,7 +66,7 @@ func (v *Version) ToTEXT(noHeaders bool) string {
 	}
 
 	table.SetAutoWrapText(false)
-	table.SetAutoFormatHeaders(true)
+	table.SetAutoFormatHeaders(false)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetCenterSeparator("")
 	table.SetColumnSeparator("")


### PR DESCRIPTION
## Description

Change the tablewriter tool to use the `_` character in header names

## Motivation and Context

Just a better look for some of the header names

## Dependencies

## How Has This Been Tested?

## Screenshots (if appropriate)

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [ ] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
- **BREAKING** note on base feature
- Basically whatever formatting we have here, just plain-text
%> command example
- next feature
- note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

### Changes

- Just header formatting and names changes

### Fixes

### Deprecated

### Removed

### Breaking Changes

