### PR TITLE
Add the ability to remove a utility definition

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -15,6 +15,8 @@
 - [get sizes](#get-sizes)
 - [get utilities](#get-utilities)
 - [launch](#launch)
+- [remove](#remove)
+- [remove utility](#remove-utility)
 - [version](#version)
 
 ## ktrouble
@@ -42,6 +44,7 @@ Available Commands:
   get         Get various internal configuration and kubernetes resource listings
   help        Help about any command
   launch      launch a kubernetes troubleshooting pod
+  remove      
   version     Express the 'version' of ktrouble.
 
 Flags:
@@ -51,6 +54,7 @@ Flags:
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
+  -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
 
 Use "ktrouble [command] --help" for more information about a command.
 ```
@@ -77,6 +81,7 @@ Global Flags:
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
+  -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
 
 Use "ktrouble add [command] --help" for more information about a command.
 ```
@@ -102,6 +107,7 @@ Global Flags:
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
+  -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
 ```
 
 [TOC](#TOC)
@@ -125,6 +131,7 @@ Global Flags:
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
+  -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
 ```
 
 [TOC](#TOC)
@@ -174,6 +181,7 @@ Global Flags:
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
+  -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
 
 Use "ktrouble get [command] --help" for more information about a command.
 ```
@@ -201,6 +209,7 @@ Global Flags:
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
+  -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
 ```
 
 [TOC](#TOC)
@@ -226,6 +235,7 @@ Global Flags:
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
+  -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
 ```
 
 [TOC](#TOC)
@@ -251,6 +261,7 @@ Global Flags:
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
+  -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
 ```
 
 [TOC](#TOC)
@@ -285,6 +296,7 @@ Global Flags:
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
+  -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
 ```
 
 [TOC](#TOC)
@@ -316,6 +328,7 @@ Global Flags:
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
+  -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
 ```
 
 [TOC](#TOC)
@@ -341,6 +354,7 @@ Global Flags:
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
+  -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
 ```
 
 [TOC](#TOC)
@@ -357,7 +371,7 @@ Usage:
   ktrouble get utilities [flags]
 
 Aliases:
-  utilities, utility, util, container, containers, image, images
+  utilities, utility, utils, util, container, containers, image, images
 
 Global Flags:
       --config string      config file (default is $HOME/.splicectl/config.yml)
@@ -366,6 +380,7 @@ Global Flags:
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
+  -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
 ```
 
 [TOC](#TOC)
@@ -397,6 +412,57 @@ Global Flags:
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
+  -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+```
+
+[TOC](#TOC)
+
+## remove
+
+```plaintext
+EXAMPLES
+	ktrouble remove utility
+
+Usage:
+  ktrouble remove [flags]
+  ktrouble remove [command]
+
+Available Commands:
+  utility     Remove a utility from the config file, or HIDE it if it is an upstream definition
+
+Global Flags:
+      --config string      config file (default is $HOME/.splicectl/config.yml)
+      --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
+  -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
+  -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
+      --no-headers         Suppress header output in Text output
+  -o, --output string      output types: json, text, yaml, gron, raw
+  -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+
+Use "ktrouble remove [command] --help" for more information about a command.
+```
+
+[TOC](#TOC)
+
+## remove utility
+
+```plaintext
+Remove a utility from the config file, or HIDE it if it is an upstream definition
+
+Usage:
+  ktrouble remove utility [flags]
+
+Flags:
+  -u, --name string   Unique name for your utility pod
+
+Global Flags:
+      --config string      config file (default is $HOME/.splicectl/config.yml)
+      --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
+  -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
+  -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
+      --no-headers         Suppress header output in Text output
+  -o, --output string      output types: json, text, yaml, gron, raw
+  -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
 ```
 
 [TOC](#TOC)
@@ -416,6 +482,7 @@ Global Flags:
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
+  -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
 ```
 
 [TOC](#TOC)

--- a/README.md
+++ b/README.md
@@ -17,36 +17,33 @@ jira readme
 
 ### To Do
 
-- [ ] KT-1:    Add EXAMPLES and Documentation
-- [ ] KT-3:    Find and add an ansible container
-- [ ] KT-8:    In the delete command, when no pods are running, exit with that description
-- [ ] KT-9:    Extend the delete command to look at the first param after delete and use that as the delete POD name
-- [ ] KT-10:   Fix a bug where the utilitydefinitions are detected as empty, and defaults are written to config.yaml
-- [ ] KT-16:   Start adding godoc comments  (In Progress)
-- [ ] KT-18:   Add command line parameters to the launch command
-- [ ] KT-20:   Add an update command to update an existing utility definition
-- [ ] KT-21:   Add a remove command to remove an existing utility definition
-- [ ] KT-22:   Add a local property "excludeFromShare" to exclude an item from being pushed
-- [ ] KT-23:   Add a "source" property, indicating if a utility object is from the upstream source
-- [ ] KT-24:   Add a pull command to display a list of utilities that are on the upstream source, but not downloaded locally, allow an "All" or "multi-select" to choose which to pull
-- [ ] KT-25:   Add a push command to push items that are not marked as "excludeFromShare"
-- [ ] KT-26:   Add a status command that will compare your local config.yaml definitions with the upstream source
+- [ ] KT-1:   Add EXAMPLES and Documentation
+- [ ] KT-3:   Find and add an ansible container
+- [ ] KT-8:   In the delete command, when no pods are running, exit with that description
+- [ ] KT-9:   Extend the delete command to look at the first param after delete and use that as the delete POD name
+- [ ] KT-10:  Fix a bug where the utilitydefinitions are detected as empty, and defaults are written to config.yaml
+- [ ] KT-16:  Start adding godoc comments (In Progress)
+- [ ] KT-18:  Add command line parameters to the launch command
+- [ ] KT-20:  Add an update command to update an existing utility definition
+- [ ] KT-22:  Add a local property "excludeFromShare" to exclude an item from being pushed
+- [ ] KT-23:  Add a "source" property, indicating if a utility object is from the upstream source
+- [ ] KT-24:  Add a pull command to display a list of utilities that are on the upstream source, but not downloaded locally, allow an "All" or "multi-select" to choose which to pull
+- [ ] KT-25:  Add a push command to push items that are not marked as "excludeFromShare"
+- [ ] KT-26:  Add a status command that will compare your local config.yaml definitions with the upstream source
 
 ### Done
 
-  - [x] KT-4:   Add a LIST for running PODs 
-  - [x] KT-5:   Add a LIST for defined container images 
-  - [x] KT-2:   Move container list details to config.yaml, create an initial version 
-  - [x] KT-12:  Add a basic-tools image combining some of the others 
-  - [x] KT-6:   Convert to real OUTPUT formats 
-  - [x] KT-11:  Read the utilitydefinitions into a global variable rather than re-read config all the time (both MAP and ARRAY) 
-  - [x] KT-7:   Replace logrus with common.Logger 
-  - [x] KT-13:  Add a bash:// column to the get pods output 
-  - [x] KT-14:  Add get sizes to display the request/limits for each size 
-  - [x] KT-15:  Turn off auto-format for headers, change header names 
-  - [x] KT-17:  Refactor for clarity 
-  - [x] KT-19:  Add an add command to add a utility definition 
-  - [x] KT-27:  Update the update of the "source" property, so that it only changes ones that are "" blank AND also in the "default" list, and setting all others to "local" 
-
-
-
+- [x] KT-4:   Add a LIST for running PODs
+- [x] KT-5:   Add a LIST for defined container images
+- [x] KT-2:   Move container list details to config.yaml, create an initial version
+- [x] KT-12:  Add a basic-tools image combining some of the others
+- [x] KT-6:   Convert to real OUTPUT formats
+- [x] KT-11:  Read the utilitydefinitions into a global variable rather than re-read config all the time (both MAP and ARRAY)
+- [x] KT-7:   Replace logrus with common.Logger
+- [x] KT-13:  Add a bash:// column to the get pods output
+- [x] KT-14:  Add get sizes to display the request/limits for each size
+- [x] KT-15:  Turn off auto-format for headers, change header names
+- [x] KT-17:  Refactor for clarity
+- [x] KT-19:  Add an add command to add a utility definition
+- [x] KT-27:  Update the update of the "source" property, so that it only changes ones that are "" blank AND also in the "default" list, and setting all others to "local"
+- [x] KT-21:  Add a remove command to remove an existing utility definition

--- a/ask/utility.go
+++ b/ask/utility.go
@@ -16,11 +16,13 @@ type (
 	}
 )
 
-func PromptForUtility(utils []objects.UtilityPod) string {
+func PromptForUtility(utils []objects.UtilityPod, showHidden bool) string {
 
 	var utilArray []string
 	for _, v := range utils {
-		utilArray = append(utilArray, v.Name)
+		if !v.Hidden || showHidden {
+			utilArray = append(utilArray, v.Name)
+		}
 	}
 	sort.Strings(utilArray)
 

--- a/cmd/add/add_utility.go
+++ b/cmd/add/add_utility.go
@@ -29,6 +29,7 @@ var utilityCmd = &cobra.Command{
 				ShowExec:     c.EnableBashLinks,
 				UtilMap:      c.UtilMap,
 				UniqIdLength: c.UniqIdLength,
+				ShowHidden:   c.ShowHidden,
 			})
 		}
 	},
@@ -70,6 +71,7 @@ func checkAddUtilityParams() bool {
 					ShowExec:     c.EnableBashLinks,
 					UtilMap:      c.UtilMap,
 					UniqIdLength: c.UniqIdLength,
+					ShowHidden:   c.ShowHidden,
 				})
 			}
 		}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"ktrouble/ask"
+	"ktrouble/common"
 
 	"github.com/spf13/cobra"
 )
@@ -17,12 +18,16 @@ var deleteCmd = &cobra.Command{
   > ktrouble delete
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		podList := c.Client.GetCreatedPods()
+		if c.Client != nil {
+			podList := c.Client.GetCreatedPods()
 
-		if len(podList.Items) > 0 {
-			selectedPod := ask.PromptForPod(podList)
+			if len(podList.Items) > 0 {
+				selectedPod := ask.PromptForPod(podList)
 
-			c.Client.DeletePod(selectedPod)
+				c.Client.DeletePod(selectedPod)
+			}
+		} else {
+			common.Logger.Warn("Cannot delete a pod, no valid kubernetes context")
 		}
 	},
 }

--- a/cmd/get/get_namespace.go
+++ b/cmd/get/get_namespace.go
@@ -1,6 +1,7 @@
 package get
 
 import (
+	"ktrouble/common"
 	"ktrouble/objects"
 
 	"github.com/spf13/cobra"
@@ -18,14 +19,18 @@ var namespaceCmd = &cobra.Command{
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		nssList := c.Client.GetNamespaces()
+		if c.Client != nil {
+			nssList := c.Client.GetNamespaces()
 
-		nsData := objects.NamespaceList{}
-		for _, v := range nssList.Items {
-			nsData.Namespace = append(nsData.Namespace, v.Name)
+			nsData := objects.NamespaceList{}
+			for _, v := range nssList.Items {
+				nsData.Namespace = append(nsData.Namespace, v.Name)
+			}
+
+			c.OutputData(&nsData, objects.TextOptions{NoHeaders: c.NoHeaders})
+		} else {
+			common.Logger.Warn("Cannot fetch namespaces, no valid kubernetes context")
 		}
-
-		c.OutputData(&nsData, objects.TextOptions{NoHeaders: c.NoHeaders})
 	},
 }
 

--- a/cmd/get/get_node.go
+++ b/cmd/get/get_node.go
@@ -1,6 +1,7 @@
 package get
 
 import (
+	"ktrouble/common"
 	"ktrouble/objects"
 
 	"github.com/spf13/cobra"
@@ -18,14 +19,18 @@ var nodeCmd = &cobra.Command{
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		nodeList := c.Client.GetNodes()
+		if c.Client != nil {
+			nodeList := c.Client.GetNodes()
 
-		nodeData := objects.NodeList{}
-		for _, v := range nodeList.Items {
-			nodeData.Node = append(nodeData.Node, v.Name)
+			nodeData := objects.NodeList{}
+			for _, v := range nodeList.Items {
+				nodeData.Node = append(nodeData.Node, v.Name)
+			}
+
+			c.OutputData(&nodeData, objects.TextOptions{NoHeaders: c.NoHeaders})
+		} else {
+			common.Logger.Warn("Cannot fetch nodes, no valid kubernetes context")
 		}
-
-		c.OutputData(&nodeData, objects.TextOptions{NoHeaders: c.NoHeaders})
 
 	},
 }

--- a/cmd/get/get_running.go
+++ b/cmd/get/get_running.go
@@ -1,6 +1,7 @@
 package get
 
 import (
+	"ktrouble/common"
 	"ktrouble/objects"
 
 	"github.com/spf13/cobra"
@@ -27,27 +28,31 @@ var runningCmd = &cobra.Command{
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		podList := c.Client.GetCreatedPods()
+		if c.Client != nil {
+			podList := c.Client.GetCreatedPods()
 
-		podData := objects.PodList{}
-		for _, v := range podList.Items {
-			status := string(v.Status.Phase)
-			if v.DeletionTimestamp != nil {
-				status = "Terminating"
+			podData := objects.PodList{}
+			for _, v := range podList.Items {
+				status := string(v.Status.Phase)
+				if v.DeletionTimestamp != nil {
+					status = "Terminating"
+				}
+				podData = append(podData, objects.Pod{
+					Name:      v.Name,
+					Namespace: v.Namespace,
+					Status:    status,
+				})
 			}
-			podData = append(podData, objects.Pod{
-				Name:      v.Name,
-				Namespace: v.Namespace,
-				Status:    status,
-			})
-		}
 
-		c.OutputData(&podData, objects.TextOptions{
-			NoHeaders:    c.NoHeaders,
-			ShowExec:     c.EnableBashLinks,
-			UtilMap:      c.UtilMap,
-			UniqIdLength: c.UniqIdLength,
-		})
+			c.OutputData(&podData, objects.TextOptions{
+				NoHeaders:    c.NoHeaders,
+				ShowExec:     c.EnableBashLinks,
+				UtilMap:      c.UtilMap,
+				UniqIdLength: c.UniqIdLength,
+			})
+		} else {
+			common.Logger.Warn("Cannot fetch running pods, no valid kubernetes context")
+		}
 
 	},
 }

--- a/cmd/get/get_serviceaccount.go
+++ b/cmd/get/get_serviceaccount.go
@@ -1,6 +1,7 @@
 package get
 
 import (
+	"ktrouble/common"
 	"ktrouble/objects"
 
 	"github.com/spf13/cobra"
@@ -23,16 +24,20 @@ EXAMPLE:
   > ktrouble get sa
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		namespace := c.Client.DetermineNamespace(c.Namespace)
+		if c.Client != nil {
+			namespace := c.Client.DetermineNamespace(c.Namespace)
 
-		sasList := c.Client.GetServiceAccounts(namespace)
+			sasList := c.Client.GetServiceAccounts(namespace)
 
-		saData := objects.ServiceAccountList{}
-		for _, v := range sasList.Items {
-			saData.ServiceAccount = append(saData.ServiceAccount, v.Name)
+			saData := objects.ServiceAccountList{}
+			for _, v := range sasList.Items {
+				saData.ServiceAccount = append(saData.ServiceAccount, v.Name)
+			}
+
+			c.OutputData(&saData, objects.TextOptions{NoHeaders: c.NoHeaders})
+		} else {
+			common.Logger.Warn("Cannot fetch service accounts, no valid kubernetes context")
 		}
-
-		c.OutputData(&saData, objects.TextOptions{NoHeaders: c.NoHeaders})
 
 	},
 }

--- a/cmd/get/get_utilities.go
+++ b/cmd/get/get_utilities.go
@@ -9,7 +9,7 @@ import (
 // utilitiesCmd represents the utilities command
 var utilitiesCmd = &cobra.Command{
 	Use:     "utilities",
-	Aliases: []string{"utility", "util", "container", "containers", "image", "images"},
+	Aliases: []string{"utility", "utils", "util", "container", "containers", "image", "images"},
 	Short:   "Get a list of supported utility container images",
 	Long: `EXAMPLE:
   Display a list of utilities defined in the configuration file
@@ -18,7 +18,13 @@ var utilitiesCmd = &cobra.Command{
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		c.OutputData(&c.UtilDefs, objects.TextOptions{NoHeaders: c.NoHeaders})
+		c.OutputData(&c.UtilDefs, objects.TextOptions{
+			NoHeaders:    c.NoHeaders,
+			ShowExec:     c.EnableBashLinks,
+			UtilMap:      c.UtilMap,
+			UniqIdLength: c.UniqIdLength,
+			ShowHidden:   c.ShowHidden,
+		})
 
 	},
 }

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -37,64 +37,68 @@ EXAMPLE:
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		utilMap := make(map[string]objects.UtilityPod)
-		for _, v := range c.UtilDefs {
-			utilMap[v.Name] = objects.UtilityPod{
-				Name:        v.Name,
-				Repository:  v.Repository,
-				ExecCommand: v.ExecCommand,
+		if c.Client != nil {
+			utilMap := make(map[string]objects.UtilityPod)
+			for _, v := range c.UtilDefs {
+				utilMap[v.Name] = objects.UtilityPod{
+					Name:        v.Name,
+					Repository:  v.Repository,
+					ExecCommand: v.ExecCommand,
+				}
 			}
-		}
 
-		utility := ""
-		if len(args) > 0 && len(args[0]) > 0 {
-			utility = args[0]
+			utility := ""
+			if len(args) > 0 && len(args[0]) > 0 {
+				utility = args[0]
+			} else {
+				utility = ask.PromptForUtility(c.UtilDefs, c.ShowHidden)
+			}
+			namespace := c.Client.DetermineNamespace(c.Namespace)
+			sa := "default"
+			if len(args) > 1 && len(args[1]) > 0 {
+				sa = args[1]
+			} else {
+				sasList := c.Client.GetServiceAccounts(namespace)
+				sa = ask.PromptForServiceAccount(sasList)
+			}
+
+			resourceSize := ask.PromptForResourceSize(c.SizeDefs)
+
+			nodeList := c.Client.GetNodes()
+			selector := ask.PromptForNodeLabels(nodeList)
+			hasSelector := "true"
+			if selector == "\"-none-\"" {
+				hasSelector = "false"
+			}
+			shortUniq := randSeq(c.UniqIdLength)
+			tc := &TemplateConfig{
+				Parameters: map[string]string{
+					"name":           fmt.Sprintf("%s-%s", utility, shortUniq),
+					"serviceAccount": sa,
+					"namespace":      namespace,
+					"registry":       utilMap[utility].Repository,
+					"limitsCpu":      c.SizeMap[resourceSize].LimitsCPU,
+					"limitsMem":      c.SizeMap[resourceSize].LimitsMEM,
+					"requestCpu":     c.SizeMap[resourceSize].RequestCPU,
+					"requestMem":     c.SizeMap[resourceSize].RequestMEM,
+					"hasSelector":    hasSelector,
+					"selector":       selector,
+				},
+			}
+
+			var tpl bytes.Buffer
+			if err := template.ApplicationsTemplate.Execute(&tpl, tc); err != nil {
+				common.Logger.WithError(err).Error("unable to generate the template data")
+			}
+
+			podManifest := tpl.String()
+
+			c.Client.CreatePod(podManifest, namespace)
+
+			fmt.Printf("kubectl -n %s exec -it %s -- %s\n", namespace, fmt.Sprintf("%s-%s", utility, shortUniq), utilMap[utility].ExecCommand)
 		} else {
-			utility = ask.PromptForUtility(c.UtilDefs)
+			common.Logger.Warn("Cannot launch a pod, no valid kubernetes context")
 		}
-		namespace := c.Client.DetermineNamespace(c.Namespace)
-		sa := "default"
-		if len(args) > 1 && len(args[1]) > 0 {
-			sa = args[1]
-		} else {
-			sasList := c.Client.GetServiceAccounts(namespace)
-			sa = ask.PromptForServiceAccount(sasList)
-		}
-
-		resourceSize := ask.PromptForResourceSize(c.SizeDefs)
-
-		nodeList := c.Client.GetNodes()
-		selector := ask.PromptForNodeLabels(nodeList)
-		hasSelector := "true"
-		if selector == "\"-none-\"" {
-			hasSelector = "false"
-		}
-		shortUniq := randSeq(c.UniqIdLength)
-		tc := &TemplateConfig{
-			Parameters: map[string]string{
-				"name":           fmt.Sprintf("%s-%s", utility, shortUniq),
-				"serviceAccount": sa,
-				"namespace":      namespace,
-				"registry":       utilMap[utility].Repository,
-				"limitsCpu":      c.SizeMap[resourceSize].LimitsCPU,
-				"limitsMem":      c.SizeMap[resourceSize].LimitsMEM,
-				"requestCpu":     c.SizeMap[resourceSize].RequestCPU,
-				"requestMem":     c.SizeMap[resourceSize].RequestMEM,
-				"hasSelector":    hasSelector,
-				"selector":       selector,
-			},
-		}
-
-		var tpl bytes.Buffer
-		if err := template.ApplicationsTemplate.Execute(&tpl, tc); err != nil {
-			common.Logger.WithError(err).Error("unable to generate the template data")
-		}
-
-		podManifest := tpl.String()
-
-		c.Client.CreatePod(podManifest, namespace)
-
-		fmt.Printf("kubectl -n %s exec -it %s -- %s\n", namespace, fmt.Sprintf("%s-%s", utility, shortUniq), utilMap[utility].ExecCommand)
 
 	},
 }

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -1,0 +1,23 @@
+package remove
+
+import (
+	"ktrouble/config"
+
+	"github.com/spf13/cobra"
+)
+
+var removeCmd = &cobra.Command{
+	Use:   "remove",
+	Args:  cobra.MinimumNArgs(1),
+	Short: "",
+	Long: `EXAMPLES
+	ktrouble remove utility`,
+	Run: func(cmd *cobra.Command, args []string) {},
+}
+
+var c *config.Config
+
+func InitSubCommands(conf *config.Config) *cobra.Command {
+	c = conf
+	return removeCmd
+}

--- a/cmd/remove/remove_utility.go
+++ b/cmd/remove/remove_utility.go
@@ -1,0 +1,77 @@
+package remove
+
+import (
+	"ktrouble/common"
+	"ktrouble/objects"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// utilityParam is used to store command line parameters
+var utilityParam objects.UtilityPod
+
+// utilityCmd represents the utility command
+var utilityCmd = &cobra.Command{
+	Use:   "utility",
+	Short: "Remove a utility from the config file, or HIDE it if it is an upstream definition",
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(utilityParam.Name) > 0 {
+			err := removeOrHideUtility()
+			if err != nil {
+				logrus.WithError(err).Error("Failed to express the version")
+			}
+			if !c.FormatOverridden {
+				c.OutputFormat = "text"
+			}
+			c.OutputData(&c.UtilDefs, objects.TextOptions{
+				NoHeaders:    c.NoHeaders,
+				ShowExec:     c.EnableBashLinks,
+				UtilMap:      c.UtilMap,
+				UniqIdLength: c.UniqIdLength,
+				ShowHidden:   c.ShowHidden,
+			})
+		}
+	},
+}
+
+func removeOrHideUtility() error {
+
+	updatedDefs := false
+	for i, v := range c.UtilDefs {
+		if utilityParam.Name == v.Name {
+			updatedDefs = true
+			// this is the one to delete
+			if v.Source == "ktrouble-utils" {
+				// hide it
+				c.UtilDefs[i].Hidden = true
+			} else {
+				// remove it from the list
+				c.UtilDefs = removeIndex(c.UtilDefs, i)
+			}
+			break
+		}
+	}
+	if updatedDefs {
+		viper.Set("utilityDefinitions", c.UtilDefs)
+		verr := viper.WriteConfig()
+		if verr != nil {
+			common.Logger.WithError(verr).Info("Failed to write config")
+			return verr
+		}
+	}
+
+	return nil
+}
+
+func removeIndex(s objects.UtilityPodList, index int) objects.UtilityPodList {
+	ret := make(objects.UtilityPodList, 0)
+	ret = append(ret, s[:index]...)
+	return append(ret, s[index+1:]...)
+}
+
+func init() {
+	removeCmd.AddCommand(utilityCmd)
+	utilityCmd.Flags().StringVarP(&utilityParam.Name, "name", "u", "", "Unique name for your utility pod")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 
 	"ktrouble/cmd/add"
 	"ktrouble/cmd/get"
+	"ktrouble/cmd/remove"
 	"ktrouble/common"
 	"ktrouble/config"
 	"ktrouble/defaults"
@@ -98,13 +99,11 @@ var RootCmd = &cobra.Command{
 			}
 		}
 
-		if os.Args[1] != "version" && os.Args[1] != "add" {
-			if os.Args[2] != "utilities" {
-				c.Client = kubernetes.New()
-				if c.Client == nil {
-					common.Logger.Fatal("failed to create a kubernetes context")
-				}
-			}
+		if os.Args[1] != "version" {
+			c.Client = kubernetes.New()
+			// if c.Client == nil {
+			// 	common.Logger.Warn("failed to create a kubernetes context")
+			// }
 		}
 	},
 }
@@ -117,6 +116,7 @@ func buildRootCmd() *cobra.Command {
 	RootCmd.PersistentFlags().StringVarP(&c.LogLevel, "log-level", "v", "", "Set the logging level: trace,debug,info,warning,error,fatal")
 	RootCmd.PersistentFlags().StringVar(&c.LogFile, "log-file", "", "Set the logging level: trace,debug,info,warning,error,fatal")
 	RootCmd.PersistentFlags().StringVarP(&c.Namespace, "namespace", "n", "", "Specify the namespace to run in, ENV NAMESPACE then -n for preference")
+	RootCmd.PersistentFlags().BoolVarP(&c.ShowHidden, "show-hidden", "s", false, "Show entries with the 'hidden' property set to 'true'")
 
 	return RootCmd
 }
@@ -127,6 +127,7 @@ func addSubCommands() {
 		// <package>.InitSubCommands(c),
 		get.InitSubCommands(c),
 		add.InitSubCommands(c),
+		remove.InitSubCommands(c),
 	)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,7 @@ type (
 		Namespace          string
 		EnableBashLinks    bool
 		UniqIdLength       int
+		ShowHidden         bool
 		UtilMap            map[string]objects.UtilityPod
 		UtilDefs           objects.UtilityPodList
 		SizeMap            map[string]objects.ResourceSize

--- a/defaults/utility_definitions.go
+++ b/defaults/utility_definitions.go
@@ -13,6 +13,7 @@ func UtilityDefinitions() []objects.UtilityPod {
 			ExecCommand:      "/bin/sh",
 			Source:           "ktrouble-utils",
 			ExcludeFromShare: false,
+			Hidden:           false,
 		},
 		{
 			Name:             "psql-curl",
@@ -20,6 +21,7 @@ func UtilityDefinitions() []objects.UtilityPod {
 			ExecCommand:      "/bin/bash",
 			Source:           "ktrouble-utils",
 			ExcludeFromShare: false,
+			Hidden:           false,
 		},
 		{
 			Name:             "psqlutils15",
@@ -27,6 +29,7 @@ func UtilityDefinitions() []objects.UtilityPod {
 			ExecCommand:      "/bin/bash",
 			Source:           "ktrouble-utils",
 			ExcludeFromShare: false,
+			Hidden:           false,
 		},
 		{
 			Name:             "psqlutils14",
@@ -34,6 +37,7 @@ func UtilityDefinitions() []objects.UtilityPod {
 			ExecCommand:      "/bin/bash",
 			Source:           "ktrouble-utils",
 			ExcludeFromShare: false,
+			Hidden:           false,
 		},
 		{
 			Name:             "awscli",
@@ -41,6 +45,7 @@ func UtilityDefinitions() []objects.UtilityPod {
 			ExecCommand:      "/bin/bash",
 			Source:           "ktrouble-utils",
 			ExcludeFromShare: false,
+			Hidden:           false,
 		},
 		{
 			Name:             "gcloudutils",
@@ -48,6 +53,7 @@ func UtilityDefinitions() []objects.UtilityPod {
 			ExecCommand:      "/bin/bash",
 			Source:           "ktrouble-utils",
 			ExcludeFromShare: false,
+			Hidden:           false,
 		},
 		{
 			Name:             "azutils",
@@ -55,6 +61,7 @@ func UtilityDefinitions() []objects.UtilityPod {
 			ExecCommand:      "/bin/bash",
 			Source:           "ktrouble-utils",
 			ExcludeFromShare: false,
+			Hidden:           false,
 		},
 		{
 			Name:             "mysqlutils5",
@@ -62,6 +69,7 @@ func UtilityDefinitions() []objects.UtilityPod {
 			ExecCommand:      "/bin/bash",
 			Source:           "ktrouble-utils",
 			ExcludeFromShare: false,
+			Hidden:           false,
 		},
 		{
 			Name:             "mysqlutils8",
@@ -69,6 +77,7 @@ func UtilityDefinitions() []objects.UtilityPod {
 			ExecCommand:      "/bin/bash",
 			Source:           "ktrouble-utils",
 			ExcludeFromShare: false,
+			Hidden:           false,
 		},
 		{
 			Name:             "redis6",
@@ -76,6 +85,7 @@ func UtilityDefinitions() []objects.UtilityPod {
 			ExecCommand:      "/bin/bash",
 			Source:           "ktrouble-utils",
 			ExcludeFromShare: false,
+			Hidden:           false,
 		},
 		{
 			Name:             "curl",
@@ -83,6 +93,7 @@ func UtilityDefinitions() []objects.UtilityPod {
 			ExecCommand:      "/bin/sh",
 			Source:           "ktrouble-utils",
 			ExcludeFromShare: false,
+			Hidden:           false,
 		},
 		{
 			Name:             "basic-tools",
@@ -90,6 +101,7 @@ func UtilityDefinitions() []objects.UtilityPod {
 			ExecCommand:      "/bin/bash",
 			Source:           "ktrouble-utils",
 			ExcludeFromShare: false,
+			Hidden:           false,
 		},
 	}
 

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -35,17 +35,17 @@ func New() KubernetesClient {
 
 	cfg, err := restConfig()
 	if err != nil {
-		common.Logger.WithError(err).Error("could not get config")
+		common.Logger.WithError(err).Debug("could not get config")
 		return nil
 	}
 	if cfg == nil {
-		common.Logger.Error("failed to determine kubernetes config")
+		common.Logger.Debug("failed to determine kubernetes config")
 		return nil
 	}
 
 	client, err := kofficial.NewForConfig(cfg)
 	if err != nil {
-		common.Logger.WithError(err).Error("could not create client from config")
+		common.Logger.WithError(err).Debug("could not create client from config")
 		return nil
 	}
 

--- a/objects/text_options.go
+++ b/objects/text_options.go
@@ -6,5 +6,6 @@ type (
 		ShowExec     bool
 		UtilMap      map[string]UtilityPod
 		UniqIdLength int
+		ShowHidden   bool
 	}
 )

--- a/objects/utility.go
+++ b/objects/utility.go
@@ -21,6 +21,7 @@ type UtilityPod struct {
 	ExecCommand      string `json:"execcommand"`
 	Source           string `json:"source"`
 	ExcludeFromShare bool   `json:"excludefromshare"`
+	Hidden           bool   `json:"hidden"`
 }
 
 // ToJSON - Write the output as JSON
@@ -94,12 +95,14 @@ func (up *UtilityPodList) ToTEXT(to TextOptions) string {
 	sort.Strings(nameList)
 
 	for _, v := range nameList {
-		row = []string{
-			mapList[v].Name,
-			mapList[v].Repository,
-			mapList[v].ExecCommand,
+		if !mapList[v].Hidden || to.ShowHidden {
+			row = []string{
+				mapList[v].Name,
+				mapList[v].Repository,
+				mapList[v].ExecCommand,
+			}
+			table.Append(row)
 		}
-		table.Append(row)
 	}
 
 	table.Render()


### PR DESCRIPTION
## Description

Working towards CRUD operations for utility definitions, as well as a central repository interaction for the utility definitions.  This handles the `remove` operation

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Dependencies
<!--- If this fix is dependent on code in other repos to be deployed, list that here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [ ] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
- **BREAKING** note on base feature
- Basically whatever formatting we have here, just plain-text
%> command example
- next feature
- note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

- Add a `remove utility` command to remove a local entry from the `config.yaml` file, or `hide` the entry if it is an upstream definition
- Fix the handling of the kubernetes context, adding checking to all routines that requires a valid context
- Added a `hidden` property to the `utilityDefinitions` section of `config.yaml`

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes
