### PR TITLE
Add the update utility definition feature, plus field specifier

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -6,6 +6,7 @@
 - [add](#add)
 - [add utility](#add-utility)
 - [delete](#delete)
+- [fields](#fields)
 - [get](#get)
 - [get namespace](#get-namespace)
 - [get node](#get-node)
@@ -17,6 +18,8 @@
 - [launch](#launch)
 - [remove](#remove)
 - [remove utility](#remove-utility)
+- [update](#update)
+- [update utility](#update-utility)
 - [version](#version)
 
 ## ktrouble
@@ -40,15 +43,18 @@ Available Commands:
   add         
   completion  Generate the autocompletion script for the specified shell
   delete      Delete PODs that have been created by ktrouble
+  fields      Display a list of valid fields to use with the --fields/-f parameter for each command
   genhelp     Output help from all the sub commands
   get         Get various internal configuration and kubernetes resource listings
   help        Help about any command
   launch      launch a kubernetes troubleshooting pod
   remove      
+  update      
   version     Express the 'version' of ktrouble.
 
 Flags:
       --config string      config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
       --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
   -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
@@ -76,6 +82,7 @@ Available Commands:
 
 Global Flags:
       --config string      config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
       --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
   -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
@@ -102,6 +109,7 @@ Flags:
 
 Global Flags:
       --config string      config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
       --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
   -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
@@ -126,6 +134,28 @@ Usage:
 
 Global Flags:
       --config string      config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
+      --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
+  -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
+  -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
+      --no-headers         Suppress header output in Text output
+  -o, --output string      output types: json, text, yaml, gron, raw
+  -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+```
+
+[TOC](#TOC)
+
+## fields
+
+```plaintext
+Display a list of valid fields to use with the --fields/-f parameter for each command
+
+Usage:
+  ktrouble fields [flags]
+
+Global Flags:
+      --config string      config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
       --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
   -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
@@ -176,6 +206,7 @@ Available Commands:
 
 Global Flags:
       --config string      config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
       --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
   -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
@@ -204,6 +235,7 @@ Aliases:
 
 Global Flags:
       --config string      config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
       --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
   -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
@@ -230,6 +262,7 @@ Aliases:
 
 Global Flags:
       --config string      config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
       --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
   -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
@@ -256,6 +289,7 @@ Aliases:
 
 Global Flags:
       --config string      config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
       --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
   -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
@@ -291,6 +325,7 @@ Aliases:
 
 Global Flags:
       --config string      config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
       --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
   -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
@@ -323,6 +358,7 @@ Aliases:
 
 Global Flags:
       --config string      config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
       --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
   -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
@@ -349,6 +385,7 @@ Aliases:
 
 Global Flags:
       --config string      config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
       --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
   -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
@@ -375,6 +412,7 @@ Aliases:
 
 Global Flags:
       --config string      config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
       --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
   -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
@@ -407,6 +445,7 @@ Aliases:
 
 Global Flags:
       --config string      config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
       --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
   -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
@@ -432,6 +471,7 @@ Available Commands:
 
 Global Flags:
       --config string      config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
       --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
   -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
@@ -457,6 +497,61 @@ Flags:
 
 Global Flags:
       --config string      config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
+      --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
+  -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
+  -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
+      --no-headers         Suppress header output in Text output
+  -o, --output string      output types: json, text, yaml, gron, raw
+  -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+```
+
+[TOC](#TOC)
+
+## update
+
+```plaintext
+EXAMPLES
+	ktrouble update utility
+
+Usage:
+  ktrouble update [flags]
+  ktrouble update [command]
+
+Available Commands:
+  utility     
+
+Global Flags:
+      --config string      config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
+      --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
+  -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
+  -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
+      --no-headers         Suppress header output in Text output
+  -o, --output string      output types: json, text, yaml, gron, raw
+  -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+
+Use "ktrouble update [command] --help" for more information about a command.
+```
+
+[TOC](#TOC)
+
+## update utility
+
+```plaintext
+Usage:
+  ktrouble update utility [flags]
+
+Flags:
+  -c, --cmd string          Default shell/command to use when 'exec'ing into the POD
+  -u, --name string         Unique name for your utility pod
+  -r, --repository string   Repository and tag for your utility container, eg: cmaahs/basic-tools:latest
+  -e, --toggle-exclude      Switch the current 'excludeFromShare' flag for the utility definition
+      --toggle-hidden       Switch the current 'hidden' flag for the utility definition
+
+Global Flags:
+      --config string      config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
       --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
   -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
@@ -477,6 +572,7 @@ Usage:
 
 Global Flags:
       --config string      config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
       --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
   -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
   -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference

--- a/README.md
+++ b/README.md
@@ -24,9 +24,6 @@ jira readme
 - [ ] KT-10:  Fix a bug where the utilitydefinitions are detected as empty, and defaults are written to config.yaml
 - [ ] KT-16:  Start adding godoc comments (In Progress)
 - [ ] KT-18:  Add command line parameters to the launch command
-- [ ] KT-20:  Add an update command to update an existing utility definition
-- [ ] KT-22:  Add a local property "excludeFromShare" to exclude an item from being pushed
-- [ ] KT-23:  Add a "source" property, indicating if a utility object is from the upstream source
 - [ ] KT-24:  Add a pull command to display a list of utilities that are on the upstream source, but not downloaded locally, allow an "All" or "multi-select" to choose which to pull
 - [ ] KT-25:  Add a push command to push items that are not marked as "excludeFromShare"
 - [ ] KT-26:  Add a status command that will compare your local config.yaml definitions with the upstream source
@@ -47,3 +44,6 @@ jira readme
 - [x] KT-19:  Add an add command to add a utility definition
 - [x] KT-27:  Update the update of the "source" property, so that it only changes ones that are "" blank AND also in the "default" list, and setting all others to "local"
 - [x] KT-21:  Add a remove command to remove an existing utility definition
+- [x] KT-22:  Add a local property "excludeFromShare" to exclude an item from being pushed
+- [x] KT-23:  Add a "source" property, indicating if a utility object is from the upstream source
+- [x] KT-20:  Add an update command to update an existing utility definition

--- a/cmd/fields.go
+++ b/cmd/fields.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// fieldsCmd represents the fields command
+var fieldsCmd = &cobra.Command{
+	Use:   "fields",
+	Short: "Display a list of valid fields to use with the --fields/-f parameter for each command",
+	Run: func(cmd *cobra.Command, args []string) {
+		displayFieldHelp()
+	},
+}
+
+func displayFieldHelp() {
+
+	help := `A list of valid FIELDS that can be specified by command:
+
+  COMMAND: get|add|update|remove utility
+
+      FIELDS: NAME, REPOSITORY, EXEC, HIDDEN, EXCLUDED
+`
+
+	fmt.Println(help)
+}
+
+func init() {
+	RootCmd.AddCommand(fieldsCmd)
+}

--- a/cmd/genhelp.go
+++ b/cmd/genhelp.go
@@ -140,5 +140,5 @@ func dumpHelpConfluence(c *cobra.Command, root bool, parent string) {
 }
 func init() {
 	RootCmd.AddCommand(genhelpCmd)
-	genhelpCmd.Flags().StringP("format", "f", "markdown", "Specify the format for the doc file: markdown|confluence")
+	genhelpCmd.Flags().String("format", "markdown", "Specify the format for the doc file: markdown|confluence")
 }

--- a/cmd/get/get_utilities.go
+++ b/cmd/get/get_utilities.go
@@ -19,11 +19,9 @@ var utilitiesCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 
 		c.OutputData(&c.UtilDefs, objects.TextOptions{
-			NoHeaders:    c.NoHeaders,
-			ShowExec:     c.EnableBashLinks,
-			UtilMap:      c.UtilMap,
-			UniqIdLength: c.UniqIdLength,
-			ShowHidden:   c.ShowHidden,
+			NoHeaders:  c.NoHeaders,
+			ShowHidden: c.ShowHidden,
+			Fields:     c.Fields,
 		})
 
 	},

--- a/cmd/remove/remove_utility.go
+++ b/cmd/remove/remove_utility.go
@@ -20,17 +20,16 @@ var utilityCmd = &cobra.Command{
 		if len(utilityParam.Name) > 0 {
 			err := removeOrHideUtility()
 			if err != nil {
-				logrus.WithError(err).Error("Failed to express the version")
+				logrus.WithError(err).Error("Failed to remove the utility definition")
 			}
 			if !c.FormatOverridden {
 				c.OutputFormat = "text"
 			}
 			c.OutputData(&c.UtilDefs, objects.TextOptions{
-				NoHeaders:    c.NoHeaders,
-				ShowExec:     c.EnableBashLinks,
-				UtilMap:      c.UtilMap,
-				UniqIdLength: c.UniqIdLength,
-				ShowHidden:   c.ShowHidden,
+				NoHeaders:        c.NoHeaders,
+				ShowHidden:       true,
+				Fields:           c.Fields,
+				AdditionalFields: []string{"HIDDEN"},
 			})
 		}
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"ktrouble/cmd/add"
 	"ktrouble/cmd/get"
 	"ktrouble/cmd/remove"
+	"ktrouble/cmd/update"
 	"ktrouble/common"
 	"ktrouble/config"
 	"ktrouble/defaults"
@@ -117,6 +118,7 @@ func buildRootCmd() *cobra.Command {
 	RootCmd.PersistentFlags().StringVar(&c.LogFile, "log-file", "", "Set the logging level: trace,debug,info,warning,error,fatal")
 	RootCmd.PersistentFlags().StringVarP(&c.Namespace, "namespace", "n", "", "Specify the namespace to run in, ENV NAMESPACE then -n for preference")
 	RootCmd.PersistentFlags().BoolVarP(&c.ShowHidden, "show-hidden", "s", false, "Show entries with the 'hidden' property set to 'true'")
+	RootCmd.PersistentFlags().StringSliceVarP(&c.Fields, "fields", "f", []string{}, "Specify an array of field names: eg, --fields 'NAME,REPOSITORY'")
 
 	return RootCmd
 }
@@ -128,6 +130,7 @@ func addSubCommands() {
 		get.InitSubCommands(c),
 		add.InitSubCommands(c),
 		remove.InitSubCommands(c),
+		update.InitSubCommands(c),
 	)
 }
 

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -1,0 +1,23 @@
+package update
+
+import (
+	"ktrouble/config"
+
+	"github.com/spf13/cobra"
+)
+
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Args:  cobra.MinimumNArgs(1),
+	Short: "",
+	Long: `EXAMPLES
+	ktrouble update utility`,
+	Run: func(cmd *cobra.Command, args []string) {},
+}
+
+var c *config.Config
+
+func InitSubCommands(conf *config.Config) *cobra.Command {
+	c = conf
+	return updateCmd
+}

--- a/cmd/update/update_utility.go
+++ b/cmd/update/update_utility.go
@@ -1,0 +1,85 @@
+package update
+
+import (
+	"ktrouble/common"
+	"ktrouble/objects"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// utilityParam is used to store command line parameters
+var utilityParam objects.UtilityPod
+
+// utilityCmd represents the utility command
+var utilityCmd = &cobra.Command{
+	Use:   "utility",
+	Short: "",
+	Run: func(cmd *cobra.Command, args []string) {
+		u, err := updateUtility()
+		if err != nil {
+			logrus.WithError(err).Error("Failed to update the utility definition")
+		}
+		if !c.FormatOverridden {
+			c.OutputFormat = "text"
+		}
+		updated := objects.UtilityPodList{}
+		updated = append(updated, u)
+		c.OutputData(&updated, objects.TextOptions{
+			NoHeaders:        c.NoHeaders,
+			ShowHidden:       true,
+			Fields:           c.Fields,
+			AdditionalFields: []string{"HIDDEN", "EXCLUDED"},
+		})
+	},
+}
+
+func updateUtility() (objects.UtilityPod, error) {
+
+	updatedUtilty := false
+	updatedDef := objects.UtilityPod{}
+	for i, v := range c.UtilDefs {
+		if utilityParam.Name == v.Name {
+			if len(utilityParam.Repository) > 0 {
+				c.UtilDefs[i].Repository = utilityParam.Repository
+				updatedUtilty = true
+			}
+			if len(utilityParam.ExecCommand) > 0 {
+				c.UtilDefs[i].ExecCommand = utilityParam.ExecCommand
+				updatedUtilty = true
+			}
+			if utilityParam.ExcludeFromShare {
+				c.UtilDefs[i].ExcludeFromShare = !c.UtilDefs[i].ExcludeFromShare
+				updatedUtilty = true
+			}
+			if utilityParam.Hidden {
+				c.UtilDefs[i].Hidden = !c.UtilDefs[i].Hidden
+				updatedUtilty = true
+			}
+			updatedDef = c.UtilDefs[i]
+		}
+	}
+	if updatedUtilty {
+		viper.Set("utilityDefinitions", c.UtilDefs)
+		verr := viper.WriteConfig()
+		if verr != nil {
+			common.Logger.WithError(verr).Info("Failed to write config")
+			return updatedDef, verr
+		}
+	} else {
+		common.Logger.Warn("The utility, %s, was not updated, perhaps a mis-matched name")
+	}
+
+	return updatedDef, nil
+}
+
+func init() {
+	updateCmd.AddCommand(utilityCmd)
+	utilityCmd.Flags().StringVarP(&utilityParam.Name, "name", "u", "", "Unique name for your utility pod")
+	utilityCmd.Flags().StringVarP(&utilityParam.Repository, "repository", "r", "", "Repository and tag for your utility container, eg: cmaahs/basic-tools:latest")
+	utilityCmd.Flags().StringVarP(&utilityParam.ExecCommand, "cmd", "c", "", "Default shell/command to use when 'exec'ing into the POD")
+	utilityCmd.Flags().BoolVarP(&utilityParam.ExcludeFromShare, "toggle-exclude", "e", false, "Switch the current 'excludeFromShare' flag for the utility definition")
+	utilityCmd.Flags().BoolVar(&utilityParam.Hidden, "toggle-hidden", false, "Switch the current 'hidden' flag for the utility definition")
+
+}

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,7 @@ type (
 		SizeDefs           objects.ResourceSizeList
 		NodeSelectorLabels []string
 		Client             kubernetes.KubernetesClient
+		Fields             []string
 	}
 
 	Outputtable interface {

--- a/objects/text_options.go
+++ b/objects/text_options.go
@@ -2,10 +2,12 @@ package objects
 
 type (
 	TextOptions struct {
-		NoHeaders    bool
-		ShowExec     bool
-		UtilMap      map[string]UtilityPod
-		UniqIdLength int
-		ShowHidden   bool
+		NoHeaders        bool
+		ShowExec         bool
+		UtilMap          map[string]UtilityPod
+		UniqIdLength     int
+		ShowHidden       bool
+		Fields           []string
+		AdditionalFields []string
 	}
 )


### PR DESCRIPTION
## Description

Working towards CRUD operations for utility definitions, as well as a central repository interaction for the utility definitions.  This handles the `update` command

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Dependencies
<!--- If this fix is dependent on code in other repos to be deployed, list that here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [ ] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
- **BREAKING** note on base feature
- Basically whatever formatting we have here, just plain-text
%> command example
- next feature
- note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

- Add the `update utility` command to change settings on an existing `utilityDefinition` in the `config.yaml`
- Add `--fields/-f` parameter to allow the selection of fields out output, eg --fields "NAME,REPOSITORY"
- Add a `fields` command to display the valid FIELD identifiers per command


### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes
