### PR TITLE
Add git configuration commands

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -19,6 +19,8 @@
 - [pull](#pull)
 - [remove](#remove)
 - [remove utility](#remove-utility)
+- [set](#set)
+- [set config](#set-config)
 - [update](#update)
 - [update utility](#update-utility)
 - [version](#version)
@@ -51,6 +53,7 @@ Available Commands:
   launch      launch a kubernetes troubleshooting pod
   pull        Pull utility definitions from git
   remove      
+  set         
   update      
   version     Express the 'version' of ktrouble.
 
@@ -518,6 +521,72 @@ Usage:
 
 Flags:
   -u, --name string   Unique name for your utility pod
+
+Global Flags:
+      --config string      config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
+      --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
+  -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
+  -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
+      --no-headers         Suppress header output in Text output
+  -o, --output string      output types: json, text, yaml, gron, raw
+  -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+```
+
+[TOC](#TOC)
+
+## set
+
+```plaintext
+EXAMPLES
+	ktrouble set gituser
+
+Usage:
+  ktrouble set [flags]
+  ktrouble set [command]
+
+Available Commands:
+  config      Set git configuration options
+
+Global Flags:
+      --config string      config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
+      --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
+  -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
+  -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
+      --no-headers         Suppress header output in Text output
+  -o, --output string      output types: json, text, yaml, gron, raw
+  -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+
+Use "ktrouble set [command] --help" for more information about a command.
+```
+
+[TOC](#TOC)
+
+## set config
+
+```plaintext
+EXAMPLE:
+  If you store your git personal access token in an ENV variable, you can specify
+  the variable name.
+
+  > ktrouble set config --user christopher.maahs --tokenvar GLA_TOKEN
+
+EXAMPLE:
+  If you don't store your personal access token in an ENV variable, it can be
+  stored directly in the config.yaml file.  Don't forgot to add a 'space' in
+  front of running this next command so the token doesn't end up in your
+  history file, if you have that option set in your shell
+
+  > ktrouble set config --user christopher.maahs --token <your token>
+
+Usage:
+  ktrouble set config [flags]
+
+Flags:
+      --token string      Set your git personal token
+      --tokenvar string   Set the name of the ENV VAR that contains your git personal token
+  -u, --user string       Set your git username
 
 Global Flags:
       --config string      config file (default is $HOME/.splicectl/config.yml)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ jira readme
 - [ ] KT-18:  Add command line parameters to the launch command
 - [ ] KT-25:  Add a push command to push items that are not marked as "excludeFromShare"
 - [ ] KT-26:  Add a status command that will compare your local config.yaml definitions with the upstream source
-- [ ] KT-28:  Add set gituser, set gittokenvar, and set gittoken to facilitate setting these config.yaml settings for interation with git
 
 ### Done
 
@@ -48,3 +47,4 @@ jira readme
 - [x] KT-23:  Add a "source" property, indicating if a utility object is from the upstream source
 - [x] KT-20:  Add an update command to update an existing utility definition
 - [x] KT-24:  Add a pull command to display a list of utilities that are on the upstream source, but not downloaded locally, allow an "All" or "multi-select" to choose which to pull
+- [x] KT-28:  Add set gituser, set gittokenvar, and set gittoken to facilitate setting these config.yaml settings for interation with git

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -37,20 +37,20 @@ func pullUtilityDefinitions() {
 
 	gitUser := viper.GetString("gitUser")
 	if len(gitUser) == 0 {
-		common.Logger.Fatal("gitUser is not set")
+		common.Logger.Fatal("gitUser is not set, use 'ktrouble set config --help'")
 	}
 	gitTokenVar := ""
 	gitToken := viper.GetString("gitToken")
 	if len(gitToken) == 0 {
 		gitTokenVar = viper.GetString("gitTokenVar")
 		if len(gitTokenVar) == 0 {
-			common.Logger.Fatal("gitToken or gitTokenVar config option is not set")
+			common.Logger.Fatal("gitToken or gitTokenVar config option is not set, use 'ktrouble set config --help'")
 		}
 		gitToken = os.Getenv(gitTokenVar)
 	}
 
 	if len(gitToken) == 0 {
-		common.Logger.Fatalf("no git token set, gitToken or %s ENV VAR is not set", gitTokenVar)
+		common.Logger.Fatalf("no git token set, gitToken or %s ENV VAR is not set, use 'ktrouble set config --help'", gitTokenVar)
 	}
 
 	storer = memory.NewStorage()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"ktrouble/cmd/add"
 	"ktrouble/cmd/get"
 	"ktrouble/cmd/remove"
+	"ktrouble/cmd/set"
 	"ktrouble/cmd/update"
 	"ktrouble/common"
 	"ktrouble/config"
@@ -131,6 +132,7 @@ func addSubCommands() {
 		add.InitSubCommands(c),
 		remove.InitSubCommands(c),
 		update.InitSubCommands(c),
+		set.InitSubCommands(c),
 	)
 }
 

--- a/cmd/set/set.go
+++ b/cmd/set/set.go
@@ -1,0 +1,23 @@
+package set
+
+import (
+	"ktrouble/config"
+
+	"github.com/spf13/cobra"
+)
+
+var setCmd = &cobra.Command{
+	Use:   "set",
+	Args:  cobra.MinimumNArgs(1),
+	Short: "",
+	Long: `EXAMPLES
+	ktrouble set gituser`,
+	Run: func(cmd *cobra.Command, args []string) {},
+}
+
+var c *config.Config
+
+func InitSubCommands(conf *config.Config) *cobra.Command {
+	c = conf
+	return setCmd
+}

--- a/cmd/set/set_config.go
+++ b/cmd/set/set_config.go
@@ -1,0 +1,70 @@
+package set
+
+import (
+	"ktrouble/common"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type gitUserParam struct {
+	Name     string
+	TokenVar string
+	Token    string
+}
+
+var p gitUserParam
+
+// gitconfigCmd represents the gituser command
+var gitconfigCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Set git configuration options",
+	Long: `EXAMPLE:
+  If you store your git personal access token in an ENV variable, you can specify
+  the variable name.
+
+  > ktrouble set config --user christopher.maahs --tokenvar GLA_TOKEN
+
+EXAMPLE:
+  If you don't store your personal access token in an ENV variable, it can be
+  stored directly in the config.yaml file.  Don't forgot to add a 'space' in
+  front of running this next command so the token doesn't end up in your
+  history file, if you have that option set in your shell
+
+  > ktrouble set config --user christopher.maahs --token <your token>
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		err := saveConfig()
+		if err != nil {
+			logrus.WithError(err).Error("Failed to save the gitUser property")
+		}
+	},
+}
+
+func saveConfig() error {
+
+	if len(p.Name) > 0 {
+		viper.Set("gitUser", p.Name)
+	}
+	if len(p.TokenVar) > 0 {
+		viper.Set("gitTokenVar", p.TokenVar)
+	}
+	if len(p.Token) > 0 {
+		viper.Set("gitToken", p.Token)
+	}
+	verr := viper.WriteConfig()
+	if verr != nil {
+		common.Logger.WithError(verr).Info("Failed to write config")
+		return verr
+	}
+	return nil
+}
+
+func init() {
+	setCmd.AddCommand(gitconfigCmd)
+
+	gitconfigCmd.Flags().StringVarP(&p.Name, "user", "u", "", "Set your git username")
+	gitconfigCmd.Flags().StringVar(&p.TokenVar, "tokenvar", "", "Set the name of the ENV VAR that contains your git personal token")
+	gitconfigCmd.Flags().StringVar(&p.Token, "token", "", "Set your git personal token")
+}


### PR DESCRIPTION
## Description

Add commands to set git configuration options in the config.yaml file

## Changelog Inclusions

### Additions

- Add `set config` to allow setting git user, and git token

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes
