### PR TITLE
Add a status command to give basic info on local to remote differences

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -21,6 +21,7 @@
 - [remove utility](#remove-utility)
 - [set](#set)
 - [set config](#set-config)
+- [status](#status)
 - [update](#update)
 - [update utility](#update-utility)
 - [version](#version)
@@ -54,6 +55,7 @@ Available Commands:
   pull        Pull utility definitions from git
   remove      
   set         
+  status      Get a comparison of the local utility definitions with the upstream one
   update      
   version     Express the 'version' of ktrouble.
 
@@ -587,6 +589,28 @@ Flags:
       --token string      Set your git personal token
       --tokenvar string   Set the name of the ENV VAR that contains your git personal token
   -u, --user string       Set your git username
+
+Global Flags:
+      --config string      config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
+      --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
+  -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
+  -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
+      --no-headers         Suppress header output in Text output
+  -o, --output string      output types: json, text, yaml, gron, raw
+  -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+```
+
+[TOC](#TOC)
+
+## status
+
+```plaintext
+EXAMPLE:
+  > ktrouble status
+
+Usage:
+  ktrouble status [flags]
 
 Global Flags:
       --config string      config file (default is $HOME/.splicectl/config.yml)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jira readme
 - [ ] KT-16:  Start adding godoc comments (In Progress)
 - [ ] KT-18:  Add command line parameters to the launch command
 - [ ] KT-25:  Add a push command to push items that are not marked as "excludeFromShare"
-- [ ] KT-26:  Add a status command that will compare your local config.yaml definitions with the upstream source
+- [ ] KT-29:  Add rebase command to pull ALL remote items, overwriting local versions
 
 ### Done
 
@@ -48,3 +48,6 @@ jira readme
 - [x] KT-20:  Add an update command to update an existing utility definition
 - [x] KT-24:  Add a pull command to display a list of utilities that are on the upstream source, but not downloaded locally, allow an "All" or "multi-select" to choose which to pull
 - [x] KT-28:  Add set gituser, set gittokenvar, and set gittoken to facilitate setting these config.yaml settings for interation with git
+- [x] KT-26:  Add a status command that will compare your local config.yaml definitions with the upstream source
+
+

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -2,21 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"ktrouble/ask"
 	"ktrouble/common"
-	"ktrouble/objects"
-	"os"
-	"strings"
 
-	billy "github.com/go-git/go-billy/v5"
-	memfs "github.com/go-git/go-billy/v5/memfs"
-	git "github.com/go-git/go-git/v5"
-	gitHttp "github.com/go-git/go-git/v5/plumbing/transport/http"
-	memory "github.com/go-git/go-git/v5/storage/memory"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"gopkg.in/yaml.v2"
 )
 
 // pullCmd represents the pull command
@@ -32,76 +22,8 @@ var pullCmd = &cobra.Command{
 }
 
 func pullUtilityDefinitions() {
-	var storer *memory.Storage
-	var fs billy.Filesystem
 
-	gitUser := viper.GetString("gitUser")
-	if len(gitUser) == 0 {
-		common.Logger.Fatal("gitUser is not set, use 'ktrouble set config --help'")
-	}
-	gitTokenVar := ""
-	gitToken := viper.GetString("gitToken")
-	if len(gitToken) == 0 {
-		gitTokenVar = viper.GetString("gitTokenVar")
-		if len(gitTokenVar) == 0 {
-			common.Logger.Fatal("gitToken or gitTokenVar config option is not set, use 'ktrouble set config --help'")
-		}
-		gitToken = os.Getenv(gitTokenVar)
-	}
-
-	if len(gitToken) == 0 {
-		common.Logger.Fatalf("no git token set, gitToken or %s ENV VAR is not set, use 'ktrouble set config --help'", gitTokenVar)
-	}
-
-	storer = memory.NewStorage()
-	fs = memfs.New()
-
-	_, err := git.Clone(storer, fs, &git.CloneOptions{
-		URL: "https://git.alteryx.com/futurama/farnsworth/tools/ktrouble-utils.git",
-		Auth: &gitHttp.BasicAuth{
-			Username: gitUser,
-			Password: gitToken,
-		},
-		Depth:    1,
-		Progress: nil,
-	})
-	if err != nil {
-		common.Logger.WithError(err).Fatal("Error cloning to memory")
-	}
-
-	dirInfo, derr := fs.ReadDir("/")
-	if derr != nil {
-		common.Logger.WithError(derr).Fatal("Failed to read dir")
-	}
-
-	remoteDefs := objects.UtilityPodList{}
-	remoteDefsMap := make(map[string]objects.UtilityPod, 0)
-
-	for _, di := range dirInfo {
-		if strings.HasSuffix(di.Name(), ".yaml") {
-			file, err := fs.Open(di.Name())
-			if err != nil {
-				common.Logger.Errorf("failed to open file: %s", di.Name())
-			}
-			data, err := ioutil.ReadAll(file)
-			if err != nil {
-				common.Logger.Errorf("failed to read file data from %s", di.Name())
-			}
-			utilDef := objects.UtilityPod{}
-			merr := yaml.Unmarshal(data, &utilDef)
-			if merr != nil {
-				common.Logger.Error("failed to unmarshall utility definition")
-			}
-			if missingLocally(utilDef.Name) {
-				remoteDefs = append(remoteDefs, utilDef)
-				remoteDefsMap[utilDef.Name] = utilDef
-			}
-		}
-	}
-
-	for _, v := range remoteDefs {
-		common.Logger.Warnf("Only Remote: %s", v.Name)
-	}
+	remoteDefs, remoteDefsMap := c.GitUpstream.GetNewUpstreamDefs(c.UtilDefs)
 
 	if len(remoteDefs) > 0 {
 		addUtils := ask.PromptForPulledUtility(remoteDefs)
@@ -122,15 +44,6 @@ func pullUtilityDefinitions() {
 		fmt.Println("Up to date")
 	}
 
-}
-
-func missingLocally(name string) bool {
-	for _, v := range c.UtilDefs {
-		if name == v.Name {
-			return false
-		}
-	}
-	return true
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"ktrouble/common"
 	"ktrouble/config"
 	"ktrouble/defaults"
+	"ktrouble/gitupstream"
 	"ktrouble/kubernetes"
 	"ktrouble/objects"
 
@@ -101,6 +102,27 @@ var RootCmd = &cobra.Command{
 			}
 		}
 
+		if os.Args[1] == "pull" || os.Args[1] == "push" || os.Args[1] == "status" {
+			gitUser := viper.GetString("gitUser")
+			if len(gitUser) == 0 {
+				common.Logger.Fatal("gitUser is not set, use 'ktrouble set config --help'")
+			}
+			gitTokenVar := ""
+			gitToken := viper.GetString("gitToken")
+			if len(gitToken) == 0 {
+				gitTokenVar = viper.GetString("gitTokenVar")
+				if len(gitTokenVar) == 0 {
+					common.Logger.Fatal("gitToken or gitTokenVar config option is not set, use 'ktrouble set config --help'")
+				}
+				gitToken = os.Getenv(gitTokenVar)
+			}
+
+			if len(gitToken) == 0 {
+				common.Logger.Fatalf("no git token set, gitToken or %s ENV VAR is not set, use 'ktrouble set config --help'", gitTokenVar)
+			}
+
+			c.GitUpstream = gitupstream.New(gitUser, gitToken)
+		}
 		if os.Args[1] != "version" {
 			c.Client = kubernetes.New()
 			// if c.Client == nil {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"fmt"
+	"ktrouble/objects"
+
+	"github.com/spf13/cobra"
+)
+
+// statusCmd represents the status command
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Get a comparison of the local utility definitions with the upstream one",
+	Long: `EXAMPLE:
+  > ktrouble status
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		status := utilityDefinitionStatus()
+		c.OutputData(&status, objects.TextOptions{
+			NoHeaders: c.NoHeaders,
+			Fields:    c.Fields,
+		})
+	},
+}
+
+func utilityDefinitionStatus() objects.StatusList {
+	status := objects.StatusList{}
+
+	remoteDefs, remoteDefsMap := c.GitUpstream.GetUpstreamDefs()
+
+	for _, l := range c.UtilDefs {
+		if r, ok := remoteDefsMap[l.Name]; !ok {
+			status = append(status, objects.Status{
+				Name:    l.Name,
+				Status:  "only local",
+				Exclude: fmt.Sprintf("%t", l.ExcludeFromShare),
+			})
+		} else {
+			s := compareDefs(l, r)
+			status = append(status, objects.Status{
+				Name:    l.Name,
+				Status:  s,
+				Exclude: fmt.Sprintf("%t", l.ExcludeFromShare),
+			})
+		}
+	}
+	for _, r := range remoteDefs {
+		if _, ok := c.UtilMap[r.Name]; !ok {
+			status = append(status, objects.Status{
+				Name:    r.Name,
+				Status:  "only remote",
+				Exclude: "",
+			})
+		}
+	}
+	return status
+}
+
+func compareDefs(local objects.UtilityPod, remote objects.UtilityPod) string {
+	if local.ExecCommand == remote.ExecCommand {
+		if local.Repository == remote.Repository {
+			return "same"
+		}
+	}
+	return "different"
+}
+func init() {
+	RootCmd.AddCommand(statusCmd)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"ktrouble/gitupstream"
 	"ktrouble/kubernetes"
 	"ktrouble/objects"
 	"strings"
@@ -31,6 +32,7 @@ type (
 		Fields             []string
 		GitUser            string
 		GitToken           string
+		GitUpstream        gitupstream.GitUpstream
 	}
 
 	Outputtable interface {

--- a/gitupstream/git.go
+++ b/gitupstream/git.go
@@ -1,0 +1,108 @@
+package gitupstream
+
+import (
+	"io/ioutil"
+	"ktrouble/common"
+	"ktrouble/objects"
+	"strings"
+
+	billy "github.com/go-git/go-billy/v5"
+	memfs "github.com/go-git/go-billy/v5/memfs"
+	git "github.com/go-git/go-git/v5"
+	gitHttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+	memory "github.com/go-git/go-git/v5/storage/memory"
+	"gopkg.in/yaml.v2"
+)
+
+type GitUpstream interface {
+	GetUpstreamDefs() (objects.UtilityPodList, map[string]objects.UtilityPod)
+	GetNewUpstreamDefs(localDefs objects.UtilityPodList) (objects.UtilityPodList, map[string]objects.UtilityPod)
+}
+
+type gitUpstream struct {
+	User  string
+	Token string
+}
+
+func New(user string, token string) GitUpstream {
+
+	return &gitUpstream{
+		User:  user,
+		Token: token,
+	}
+}
+
+func (gu *gitUpstream) GetUpstreamDefs() (objects.UtilityPodList, map[string]objects.UtilityPod) {
+
+	var storer *memory.Storage
+	var fs billy.Filesystem
+
+	storer = memory.NewStorage()
+	fs = memfs.New()
+
+	_, err := git.Clone(storer, fs, &git.CloneOptions{
+		URL: "https://git.alteryx.com/futurama/farnsworth/tools/ktrouble-utils.git",
+		Auth: &gitHttp.BasicAuth{
+			Username: gu.User,
+			Password: gu.Token,
+		},
+		Depth:    1,
+		Progress: nil,
+	})
+	if err != nil {
+		common.Logger.WithError(err).Fatal("Error cloning to memory")
+	}
+
+	dirInfo, derr := fs.ReadDir("/")
+	if derr != nil {
+		common.Logger.WithError(derr).Fatal("Failed to read dir")
+	}
+
+	remoteDefs := objects.UtilityPodList{}
+	remoteDefsMap := make(map[string]objects.UtilityPod, 0)
+
+	for _, di := range dirInfo {
+		if strings.HasSuffix(di.Name(), ".yaml") {
+			file, err := fs.Open(di.Name())
+			if err != nil {
+				common.Logger.Errorf("failed to open file: %s", di.Name())
+			}
+			data, err := ioutil.ReadAll(file)
+			if err != nil {
+				common.Logger.Errorf("failed to read file data from %s", di.Name())
+			}
+			utilDef := objects.UtilityPod{}
+			merr := yaml.Unmarshal(data, &utilDef)
+			if merr != nil {
+				common.Logger.Error("failed to unmarshall utility definition")
+			}
+			remoteDefs = append(remoteDefs, utilDef)
+			remoteDefsMap[utilDef.Name] = utilDef
+		}
+	}
+	return remoteDefs, remoteDefsMap
+}
+func (gu *gitUpstream) GetNewUpstreamDefs(localDefs objects.UtilityPodList) (objects.UtilityPodList, map[string]objects.UtilityPod) {
+
+	remoteDefs, _ := gu.GetUpstreamDefs()
+
+	missingDefs := objects.UtilityPodList{}
+	missingDefsMap := make(map[string]objects.UtilityPod, 0)
+
+	for _, def := range remoteDefs {
+		if missingLocally(def.Name, localDefs) {
+			missingDefs = append(missingDefs, def)
+			missingDefsMap[def.Name] = def
+		}
+	}
+	return missingDefs, missingDefsMap
+}
+
+func missingLocally(name string, localDefs objects.UtilityPodList) bool {
+	for _, v := range localDefs {
+		if name == v.Name {
+			return false
+		}
+	}
+	return true
+}

--- a/objects/status.go
+++ b/objects/status.go
@@ -1,0 +1,94 @@
+package objects
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	"ktrouble/common"
+
+	"github.com/maahsome/gron"
+	"github.com/olekukonko/tablewriter"
+	"gopkg.in/yaml.v2"
+)
+
+type StatusList []Status
+
+type Status struct {
+	Name    string `json:"name"`
+	Status  string `json:"status"`
+	Exclude string `json:"exclude"`
+}
+
+// ToJSON - Write the output as JSON
+func (s *StatusList) ToJSON() string {
+	sJSON, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		common.Logger.WithError(err).Error("Error extracting JSON")
+		return ""
+	}
+	return string(sJSON[:])
+}
+
+func (s *StatusList) ToGRON() string {
+	sJSON, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		common.Logger.WithError(err).Error("Error extracting JSON for GRON")
+	}
+	subReader := strings.NewReader(string(sJSON[:]))
+	subValues := &bytes.Buffer{}
+	ges := gron.NewGron(subReader, subValues)
+	ges.SetMonochrome(false)
+	if serr := ges.ToGron(); serr != nil {
+		common.Logger.WithError(serr).Error("Problem generating GRON syntax")
+		return ""
+	}
+	return subValues.String()
+}
+
+func (s *StatusList) ToYAML() string {
+	sYAML, err := yaml.Marshal(s)
+	if err != nil {
+		common.Logger.WithError(err).Error("Error extracting YAML")
+		return ""
+	}
+	return string(sYAML[:])
+}
+
+func (s *StatusList) ToTEXT(to TextOptions) string {
+
+	noHeaders := to.NoHeaders
+
+	buf := new(bytes.Buffer)
+	var row []string
+
+	// ************************** TableWriter ******************************
+	table := tablewriter.NewWriter(buf)
+	if !noHeaders {
+		table.SetHeader([]string{"NAME", "STATUS", "PUSH_EXCLUDE"})
+		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	}
+
+	table.SetAutoWrapText(false)
+	table.SetAutoFormatHeaders(false)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetTablePadding("\t") // pad with tabs
+	table.SetNoWhiteSpace(true)
+
+	for _, v := range *s {
+		row = []string{
+			v.Name,
+			v.Status,
+			v.Exclude,
+		}
+		table.Append(row)
+	}
+	table.Render()
+
+	return buf.String()
+}


### PR DESCRIPTION
## Description

Add a `status` command, for differences between local config and git repository.

## Changelog Inclusions

### Additions

- Added a `status` command to compare local config utility definitions with upstream definitions

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes
