### PR TITLE
Add a basic push (to default branch) feature

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -17,6 +17,7 @@
 - [get utilities](#get-utilities)
 - [launch](#launch)
 - [pull](#pull)
+- [push](#push)
 - [remove](#remove)
 - [remove utility](#remove-utility)
 - [set](#set)
@@ -53,6 +54,7 @@ Available Commands:
   help        Help about any command
   launch      launch a kubernetes troubleshooting pod
   pull        Pull utility definitions from git
+  push        Push local objects to upstream repository
   remove      
   set         
   status      Get a comparison of the local utility definitions with the upstream one
@@ -471,6 +473,28 @@ EXAMPLE:
 
 Usage:
   ktrouble pull [flags]
+
+Global Flags:
+      --config string      config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
+      --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
+  -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
+  -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
+      --no-headers         Suppress header output in Text output
+  -o, --output string      output types: json, text, yaml, gron, raw
+  -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+```
+
+[TOC](#TOC)
+
+## push
+
+```plaintext
+EXAMPLE:
+  > ktrouble push
+
+Usage:
+  ktrouble push [flags]
 
 Global Flags:
       --config string      config file (default is $HOME/.splicectl/config.yml)

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ jira readme
 - [ ] KT-10:  Fix a bug where the utilitydefinitions are detected as empty, and defaults are written to config.yaml
 - [ ] KT-16:  Start adding godoc comments (In Progress)
 - [ ] KT-18:  Add command line parameters to the launch command
-- [ ] KT-25:  Add a push command to push items that are not marked as "excludeFromShare"
 - [ ] KT-29:  Add rebase command to pull ALL remote items, overwriting local versions
+- [ ] KT-30:  Add --all to pull command, to prompt to select from ALL upstream utilities to pull from
 
 ### Done
 
@@ -49,5 +49,4 @@ jira readme
 - [x] KT-24:  Add a pull command to display a list of utilities that are on the upstream source, but not downloaded locally, allow an "All" or "multi-select" to choose which to pull
 - [x] KT-28:  Add set gituser, set gittokenvar, and set gittoken to facilitate setting these config.yaml settings for interation with git
 - [x] KT-26:  Add a status command that will compare your local config.yaml definitions with the upstream source
-
-
+- [x] KT-25:  Add a push command to push items that are not marked as "excludeFromShare"

--- a/ask/multi_utility.go
+++ b/ask/multi_utility.go
@@ -16,7 +16,7 @@ type (
 	}
 )
 
-func PromptForPulledUtility(utils objects.UtilityPodList) []string {
+func PromptForUtilityList(utils objects.UtilityPodList, prompt string) []string {
 
 	var utilArray []string
 	for _, v := range utils {
@@ -28,7 +28,7 @@ func PromptForPulledUtility(utils objects.UtilityPodList) []string {
 		{
 			Name: "utilityname",
 			Prompt: &survey.MultiSelect{
-				Message: "Choose utility definitions to add to your local configuration:",
+				Message: prompt,
 				Options: utilArray,
 			},
 		},

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -26,7 +26,8 @@ func pullUtilityDefinitions() {
 	remoteDefs, remoteDefsMap := c.GitUpstream.GetNewUpstreamDefs(c.UtilDefs)
 
 	if len(remoteDefs) > 0 {
-		addUtils := ask.PromptForPulledUtility(remoteDefs)
+		prompt := "Choose utility definitions to add to your local configuration:"
+		addUtils := ask.PromptForUtilityList(remoteDefs, prompt)
 
 		if len(addUtils) > 0 {
 			for _, v := range addUtils {

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"fmt"
+	"ktrouble/ask"
+	"ktrouble/common"
+	"ktrouble/objects"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// pushCmd represents the push command
+var pushCmd = &cobra.Command{
+	Use:   "push",
+	Short: "Push local objects to upstream repository",
+	Long: `EXAMPLE:
+  > ktrouble push
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		pushLocalDefinitions()
+	},
+}
+
+func pushLocalDefinitions() {
+
+	// Get a list of "locals"
+	localDefs := objects.UtilityPodList{}
+
+	status := UtilityDefinitionStatus()
+
+	for _, v := range status {
+		def := c.UtilMap[v.Name]
+		if def.Source == "local" && !def.ExcludeFromShare {
+			localDefs = append(localDefs, def)
+		}
+		if def.Source != "local" && !def.ExcludeFromShare && v.Status == "different" {
+			localDefs = append(localDefs, def)
+		}
+	}
+
+	prompt := "Choose utilities to submit to the remote repository:"
+	pushList := ask.PromptForUtilityList(localDefs, prompt)
+
+	if len(pushList) > 0 {
+		// Call gitupstream.PushLocals
+		uploadDefs := objects.UtilityPodList{}
+		for _, v := range pushList {
+			uploadDefs = append(uploadDefs, c.UtilMap[v])
+		}
+		if c.GitUpstream.PushLocals(uploadDefs) {
+			for _, v := range pushList {
+				for i, u := range c.UtilDefs {
+					if v == u.Name {
+						c.UtilDefs[i].Source = "ktrouble-utils"
+						break
+					}
+				}
+			}
+			viper.Set("utilityDefinitions", c.UtilDefs)
+			verr := viper.WriteConfig()
+			if verr != nil {
+				common.Logger.WithError(verr).Info("Failed to write config")
+			}
+		} else {
+			common.Logger.Error("failed to push to repository")
+		}
+	} else {
+		fmt.Println("No definitions selected")
+	}
+
+}
+
+func init() {
+	RootCmd.AddCommand(pushCmd)
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -15,7 +15,7 @@ var statusCmd = &cobra.Command{
   > ktrouble status
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		status := utilityDefinitionStatus()
+		status := UtilityDefinitionStatus()
 		c.OutputData(&status, objects.TextOptions{
 			NoHeaders: c.NoHeaders,
 			Fields:    c.Fields,
@@ -23,7 +23,7 @@ var statusCmd = &cobra.Command{
 	},
 }
 
-func utilityDefinitionStatus() objects.StatusList {
+func UtilityDefinitionStatus() objects.StatusList {
 	status := objects.StatusList{}
 
 	remoteDefs, remoteDefsMap := c.GitUpstream.GetUpstreamDefs()

--- a/gitupstream/git.go
+++ b/gitupstream/git.go
@@ -1,9 +1,11 @@
 package gitupstream
 
 import (
+	"fmt"
 	"io/ioutil"
 	"ktrouble/common"
 	"ktrouble/objects"
+	"os"
 	"strings"
 
 	billy "github.com/go-git/go-billy/v5"
@@ -17,6 +19,7 @@ import (
 type GitUpstream interface {
 	GetUpstreamDefs() (objects.UtilityPodList, map[string]objects.UtilityPod)
 	GetNewUpstreamDefs(localDefs objects.UtilityPodList) (objects.UtilityPodList, map[string]objects.UtilityPod)
+	PushLocals(localDefs objects.UtilityPodList) bool
 }
 
 type gitUpstream struct {
@@ -96,6 +99,82 @@ func (gu *gitUpstream) GetNewUpstreamDefs(localDefs objects.UtilityPodList) (obj
 		}
 	}
 	return missingDefs, missingDefsMap
+}
+
+func (gu *gitUpstream) PushLocals(localDefs objects.UtilityPodList) bool {
+
+	var storer *memory.Storage
+	var fs billy.Filesystem
+
+	storer = memory.NewStorage()
+	fs = memfs.New()
+
+	repo, err := git.Clone(storer, fs, &git.CloneOptions{
+		URL: "https://git.alteryx.com/futurama/farnsworth/tools/ktrouble-utils.git",
+		Auth: &gitHttp.BasicAuth{
+			Username: gu.User,
+			Password: gu.Token,
+		},
+		Depth:    1,
+		Progress: nil,
+	})
+	if err != nil {
+		common.Logger.WithError(err).Fatal("Error cloning to memory")
+	}
+
+	worktree, wterr := repo.Worktree()
+	if wterr != nil {
+		common.Logger.Fatal("Failed to create worktree")
+	}
+
+	adding := []string{}
+	for _, v := range localDefs {
+
+		v.Source = "ktrouble-utils"
+		defData, merr := yaml.Marshal(v)
+		if merr != nil {
+			common.Logger.Fatal("Error Marshaling YAML data for write")
+		}
+		file, err := fs.OpenFile(fmt.Sprintf("%s.yaml", v.Name), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0666)
+		if err != nil {
+			common.Logger.WithError(err).Error("failed to open file")
+			return false
+		}
+		_, werr := file.Write(defData)
+		if werr != nil {
+			common.Logger.WithError(werr).Error("failed to write to file")
+			return false
+		}
+		_, aerr := worktree.Add(fmt.Sprintf("%s.yaml", v.Name))
+		if aerr != nil {
+			common.Logger.WithError(aerr).Fatal("Failed to add file")
+		}
+		adding = append(adding, v.Name)
+	}
+
+	status, err := worktree.Status()
+	if err != nil {
+		common.Logger.Error("failed to get worktree status")
+	}
+	fmt.Println(status.String())
+
+	_, cerr := worktree.Commit(fmt.Sprintf("%s is submitting utility definition(s): %s", gu.User, strings.Join(adding, ",")), &git.CommitOptions{})
+	if cerr != nil {
+		common.Logger.WithError(cerr).Fatal("Failed to commit changes")
+	}
+
+	perr := repo.Push(&git.PushOptions{
+		Auth: &gitHttp.BasicAuth{
+			Username: gu.User,
+			Password: gu.Token,
+		},
+		RemoteName: "origin",
+	})
+	if perr != nil {
+		common.Logger.WithError(perr).Fatal("Error pushing branch to origin")
+	}
+
+	return true
 }
 
 func missingLocally(name string, localDefs objects.UtilityPodList) bool {


### PR DESCRIPTION
## Description

Add `ktrouble push` command, to round out the ability to share utility image definitions in a fairly basic way.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Dependencies
<!--- If this fix is dependent on code in other repos to be deployed, list that here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [ ] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
- **BREAKING** note on base feature
- Basically whatever formatting we have here, just plain-text
%> command example
- next feature
- note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

- Added `push` command to push changed/added utility definitions in a commit to `ktrouble-utils` repository

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes

