### PR TITLE
Add a --all to the pull command, to allow re-pullng changed definitions

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -474,6 +474,9 @@ EXAMPLE:
 Usage:
   ktrouble pull [flags]
 
+Flags:
+  -a, --all   Specify --all to list locally modified definitions as pull selections
+
 Global Flags:
       --config string      config file (default is $HOME/.splicectl/config.yml)
   -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jira readme
 - [ ] KT-16:  Start adding godoc comments (In Progress)
 - [ ] KT-18:  Add command line parameters to the launch command
 - [ ] KT-29:  Add rebase command to pull ALL remote items, overwriting local versions
-- [ ] KT-30:  Add --all to pull command, to prompt to select from ALL upstream utilities to pull from
+- [ ] KT-31:  Sort the LISTS, all of them
 
 ### Done
 
@@ -50,3 +50,4 @@ jira readme
 - [x] KT-28:  Add set gituser, set gittokenvar, and set gittoken to facilitate setting these config.yaml settings for interation with git
 - [x] KT-26:  Add a status command that will compare your local config.yaml definitions with the upstream source
 - [x] KT-25:  Add a push command to push items that are not marked as "excludeFromShare"
+- [x] KT-30:  Add --all to pull command, to prompt to select from ALL upstream utilities to pull from

--- a/cmd/fields.go
+++ b/cmd/fields.go
@@ -21,7 +21,7 @@ func displayFieldHelp() {
 
   COMMAND: get|add|update|remove utility
 
-      FIELDS: NAME, REPOSITORY, EXEC, HIDDEN, EXCLUDED
+      FIELDS: NAME, REPOSITORY, EXEC, HIDDEN, EXCLUDED, SOURCE
 `
 
 	fmt.Println(help)

--- a/gitupstream/git.go
+++ b/gitupstream/git.go
@@ -90,15 +90,15 @@ func (gu *gitUpstream) GetNewUpstreamDefs(localDefs objects.UtilityPodList) (obj
 	remoteDefs, _ := gu.GetUpstreamDefs()
 
 	missingDefs := objects.UtilityPodList{}
-	missingDefsMap := make(map[string]objects.UtilityPod, 0)
+	allDefsMap := make(map[string]objects.UtilityPod, 0)
 
 	for _, def := range remoteDefs {
 		if missingLocally(def.Name, localDefs) {
 			missingDefs = append(missingDefs, def)
-			missingDefsMap[def.Name] = def
 		}
+			allDefsMap[def.Name] = def
 	}
-	return missingDefs, missingDefsMap
+	return missingDefs, allDefsMap
 }
 
 func (gu *gitUpstream) PushLocals(localDefs objects.UtilityPodList) bool {

--- a/objects/utility.go
+++ b/objects/utility.go
@@ -126,6 +126,8 @@ func (up *UtilityPodList) ToTEXT(to TextOptions) string {
 				row = append(row, fmt.Sprintf("%t", mapList[v].Hidden))
 			case "EXCLUDED":
 				row = append(row, fmt.Sprintf("%t", mapList[v].ExcludeFromShare))
+			case "SOURCE":
+				row = append(row, mapList[v].Source)
 			}
 		}
 		if !mapList[v].Hidden || to.ShowHidden {


### PR DESCRIPTION
## Description

Add a `--all` flag so the `pull` command will prompt you for items that are different from the upstream, allowing you to re-pull those objects.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Dependencies
<!--- If this fix is dependent on code in other repos to be deployed, list that here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [ ] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
- **BREAKING** note on base feature
- Basically whatever formatting we have here, just plain-text
%> command example
- next feature
- note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

- Added a `--all` switch to the `pull` command, allowing one to true up with the upstream

### Changes

- Added `SOURCE` as a valid field for the get|add|update|remove utility commands

### Fixes

### Deprecated

### Removed

### Breaking Changes
