### PR TITLE
Make the GitURL a config.yaml based setting, remove hardcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,28 +26,36 @@ jira readme
 - [ ] KT-18:  Add command line parameters to the launch command
 - [ ] KT-29:  Add rebase command to pull ALL remote items, overwriting local versions
 - [ ] KT-31:  Sort the LISTS, all of them
+- [ ] KT-32:  Add a description/tools field, to house what tools/operation the utility definition is meant to solve
+- [ ] KT-33:  Fix the conflict between global -f/--fields and genhelp specific -f/--format (In Progress)
+- [ ] KT-34:  Make the delete command MUTLI_SELECT
+- [ ] KT-35:  Add modify alias to the update command
+- [ ] KT-36:  Allow the ability to pass in a set of labels to set for the POD
+- [ ] KT-37:  On genhelp, don't require kube context to be configured
 
 ### Done
 
-- [x] KT-4:   Add a LIST for running PODs
-- [x] KT-5:   Add a LIST for defined container images
-- [x] KT-2:   Move container list details to config.yaml, create an initial version
-- [x] KT-12:  Add a basic-tools image combining some of the others
-- [x] KT-6:   Convert to real OUTPUT formats
-- [x] KT-11:  Read the utilitydefinitions into a global variable rather than re-read config all the time (both MAP and ARRAY)
-- [x] KT-7:   Replace logrus with common.Logger
-- [x] KT-13:  Add a bash:// column to the get pods output
-- [x] KT-14:  Add get sizes to display the request/limits for each size
-- [x] KT-15:  Turn off auto-format for headers, change header names
-- [x] KT-17:  Refactor for clarity
-- [x] KT-19:  Add an add command to add a utility definition
-- [x] KT-27:  Update the update of the "source" property, so that it only changes ones that are "" blank AND also in the "default" list, and setting all others to "local"
-- [x] KT-21:  Add a remove command to remove an existing utility definition
-- [x] KT-22:  Add a local property "excludeFromShare" to exclude an item from being pushed
-- [x] KT-23:  Add a "source" property, indicating if a utility object is from the upstream source
-- [x] KT-20:  Add an update command to update an existing utility definition
-- [x] KT-24:  Add a pull command to display a list of utilities that are on the upstream source, but not downloaded locally, allow an "All" or "multi-select" to choose which to pull
-- [x] KT-28:  Add set gituser, set gittokenvar, and set gittoken to facilitate setting these config.yaml settings for interation with git
-- [x] KT-26:  Add a status command that will compare your local config.yaml definitions with the upstream source
-- [x] KT-25:  Add a push command to push items that are not marked as "excludeFromShare"
-- [x] KT-30:  Add --all to pull command, to prompt to select from ALL upstream utilities to pull from
+- [x] KT-4:   Add a LIST for running PODs 
+- [x] KT-5:   Add a LIST for defined container images 
+- [x] KT-2:   Move container list details to config.yaml, create an initial version 
+- [x] KT-12:  Add a basic-tools image combining some of the others 
+- [x] KT-6:   Convert to real OUTPUT formats 
+- [x] KT-11:  Read the utilitydefinitions into a global variable rather than re-read config all the time (both MAP and ARRAY) 
+- [x] KT-7:   Replace logrus with common.Logger 
+- [x] KT-13:  Add a bash:// column to the get pods output 
+- [x] KT-14:  Add get sizes to display the request/limits for each size 
+- [x] KT-15:  Turn off auto-format for headers, change header names 
+- [x] KT-17:  Refactor for clarity 
+- [x] KT-19:  Add an add command to add a utility definition 
+- [x] KT-27:  Update the update of the "source" property, so that it only changes ones that are "" blank AND also in the "default" list, and setting all others to "local" 
+- [x] KT-21:  Add a remove command to remove an existing utility definition 
+- [x] KT-22:  Add a local property "excludeFromShare" to exclude an item from being pushed 
+- [x] KT-23:  Add a "source" property, indicating if a utility object is from the upstream source 
+- [x] KT-20:  Add an update command to update an existing utility definition 
+- [x] KT-24:  Add a pull command to display a list of utilities that are on the upstream source, but not downloaded locally, allow an "All" or "multi-select" to choose which to pull 
+- [x] KT-28:  Add set gituser, set gittokenvar, and set gittoken to facilitate setting these config.yaml settings for interation with git 
+- [x] KT-26:  Add a status command that will compare your local config.yaml definitions with the upstream source 
+- [x] KT-25:  Add a push command to push items that are not marked as "excludeFromShare" 
+- [x] KT-30:  Add --all to pull command, to prompt to select from ALL upstream utilities to pull from 
+- [x] KT-38:  Add git URL to set config and consume in the git operations 
+

--- a/cmd/set/set_config.go
+++ b/cmd/set/set_config.go
@@ -12,6 +12,7 @@ type gitUserParam struct {
 	Name     string
 	TokenVar string
 	Token    string
+	GitURL   string
 }
 
 var p gitUserParam
@@ -53,6 +54,9 @@ func saveConfig() error {
 	if len(p.Token) > 0 {
 		viper.Set("gitToken", p.Token)
 	}
+	if len(p.GitURL) > 0 {
+		viper.Set("gitURL", p.GitURL)
+	}
 	verr := viper.WriteConfig()
 	if verr != nil {
 		common.Logger.WithError(verr).Info("Failed to write config")
@@ -67,4 +71,5 @@ func init() {
 	gitconfigCmd.Flags().StringVarP(&p.Name, "user", "u", "", "Set your git username")
 	gitconfigCmd.Flags().StringVar(&p.TokenVar, "tokenvar", "", "Set the name of the ENV VAR that contains your git personal token")
 	gitconfigCmd.Flags().StringVar(&p.Token, "token", "", "Set your git personal token")
+	gitconfigCmd.Flags().StringVar(&p.GitURL, "giturl", "", "Set the URL for the repository for upstream utils")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ type (
 		GitUser            string
 		GitToken           string
 		GitUpstream        gitupstream.GitUpstream
+		GitURL             string
 	}
 
 	Outputtable interface {

--- a/defaults/git.go
+++ b/defaults/git.go
@@ -1,0 +1,5 @@
+package defaults
+
+func GitURL() string {
+	return "https://github.com/maahsome/ktrouble-utils.git"
+}

--- a/gitupstream/git.go
+++ b/gitupstream/git.go
@@ -23,15 +23,17 @@ type GitUpstream interface {
 }
 
 type gitUpstream struct {
-	User  string
-	Token string
+	User   string
+	Token  string
+	GitURL string
 }
 
-func New(user string, token string) GitUpstream {
+func New(user string, token string, url string) GitUpstream {
 
 	return &gitUpstream{
-		User:  user,
-		Token: token,
+		User:   user,
+		Token:  token,
+		GitURL: url,
 	}
 }
 
@@ -44,7 +46,7 @@ func (gu *gitUpstream) GetUpstreamDefs() (objects.UtilityPodList, map[string]obj
 	fs = memfs.New()
 
 	_, err := git.Clone(storer, fs, &git.CloneOptions{
-		URL: "https://git.alteryx.com/futurama/farnsworth/tools/ktrouble-utils.git",
+		URL: gu.GitURL,
 		Auth: &gitHttp.BasicAuth{
 			Username: gu.User,
 			Password: gu.Token,
@@ -96,7 +98,7 @@ func (gu *gitUpstream) GetNewUpstreamDefs(localDefs objects.UtilityPodList) (obj
 		if missingLocally(def.Name, localDefs) {
 			missingDefs = append(missingDefs, def)
 		}
-			allDefsMap[def.Name] = def
+		allDefsMap[def.Name] = def
 	}
 	return missingDefs, allDefsMap
 }
@@ -110,7 +112,7 @@ func (gu *gitUpstream) PushLocals(localDefs objects.UtilityPodList) bool {
 	fs = memfs.New()
 
 	repo, err := git.Clone(storer, fs, &git.CloneOptions{
-		URL: "https://git.alteryx.com/futurama/farnsworth/tools/ktrouble-utils.git",
+		URL: gu.GitURL,
 		Auth: &gitHttp.BasicAuth{
 			Username: gu.User,
 			Password: gu.Token,


### PR DESCRIPTION
## Description

Make the GitURL a configuration based setting, remove the hardcode

## Changelog Inclusions

### Additions

### Changes

- Move the git url to the `config.yaml` file, removing hard coded git repository

### Fixes

### Deprecated

### Removed

### Breaking Changes
