### PR TITLE
Add the ability to select secrets to mount

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -1,3 +1,4 @@
+time="2023-03-07T22:11:30-06:00" level=error msg="Failed to build KUBECONFIG" error="invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable"
 # ktrouble help for all commands
 
 ## TOC
@@ -452,6 +453,9 @@ Usage:
 Aliases:
   launch, create, apply, pod, l
 
+Flags:
+      --secrets   Use this switch to prompt to mount secrets in the POD
+
 Global Flags:
       --config string      config file (default is $HOME/.splicectl/config.yml)
   -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
@@ -614,6 +618,7 @@ Usage:
 
 Flags:
       --giturl string     Set the URL for the repository for upstream utils
+      --secrets           Toggle the Prompt for Secrets default
       --token string      Set your git personal token
       --tokenvar string   Set the name of the ENV VAR that contains your git personal token
   -u, --user string       Set your git username

--- a/ask/mount_secrets.go
+++ b/ask/mount_secrets.go
@@ -1,0 +1,44 @@
+package ask
+
+import (
+	"os"
+	"sort"
+
+	"ktrouble/common"
+
+	"github.com/AlecAivazis/survey/v2"
+	v1 "k8s.io/api/core/v1"
+)
+
+type (
+	MountSecretsAnswer struct {
+		Secret []string `survey:"secret"`
+	}
+)
+
+func PromptForSecrets(secretList *v1.SecretList) []string {
+
+	var secretArray []string
+	for _, v := range secretList.Items {
+		secretArray = append(secretArray, v.Name)
+	}
+	sort.Strings(secretArray)
+
+	var secretSurvey = []*survey.Question{
+		{
+			Name: "secret",
+			Prompt: &survey.MultiSelect{
+				Message: "Choose the secrets to mount in the POD:",
+				Options: secretArray,
+			},
+		},
+	}
+
+	opts := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
+
+	secretAnswer := &MountSecretsAnswer{}
+	if err := survey.Ask(secretSurvey, secretAnswer, opts); err != nil {
+		common.Logger.WithError(err).Fatal("No service account selected")
+	}
+	return secretAnswer.Secret
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,7 +66,7 @@ var RootCmd = &cobra.Command{
 
 		logFile, _ := cmd.Flags().GetString("log-file")
 		logLevel, _ := cmd.Flags().GetString("log-level")
-		ll := "Warning"
+		ll := "Info"
 		switch strings.ToLower(logLevel) {
 		case "trace":
 			ll = "Trace"
@@ -317,6 +317,7 @@ func initConfig() {
 			logrus.WithError(verr).Info("Failed to write config")
 		}
 	}
+
 	// GitURL
 	if viper.IsSet("gitURL") {
 		c.GitURL = viper.GetString("gitURL")
@@ -324,6 +325,19 @@ func initConfig() {
 		// Set the default
 		viper.Set("gitURL", defaults.GitURL())
 		c.GitURL = defaults.GitURL()
+		verr := viper.WriteConfig()
+		if verr != nil {
+			logrus.WithError(verr).Info("Failed to write config")
+		}
+	}
+
+	// PromptForSecrets
+	if viper.IsSet("promptForSecrets") {
+		c.PromptForSecrets = viper.GetBool("promptForSecrets")
+	} else {
+		// Set the default
+		viper.Set("promptForSecrets", false)
+		c.PromptForSecrets = false
 		verr := viper.WriteConfig()
 		if verr != nil {
 			logrus.WithError(verr).Info("Failed to write config")

--- a/cmd/set/set_config.go
+++ b/cmd/set/set_config.go
@@ -8,14 +8,15 @@ import (
 	"github.com/spf13/viper"
 )
 
-type gitUserParam struct {
-	Name     string
-	TokenVar string
-	Token    string
-	GitURL   string
+type configUserParam struct {
+	Name             string
+	TokenVar         string
+	Token            string
+	GitURL           string
+	PromptForSecrets bool
 }
 
-var p gitUserParam
+var p configUserParam
 
 // gitconfigCmd represents the gituser command
 var gitconfigCmd = &cobra.Command{
@@ -47,15 +48,28 @@ func saveConfig() error {
 
 	if len(p.Name) > 0 {
 		viper.Set("gitUser", p.Name)
+		common.Logger.Info("The gitUser has been set")
 	}
 	if len(p.TokenVar) > 0 {
 		viper.Set("gitTokenVar", p.TokenVar)
+		common.Logger.Info("The gitTokenVar has been set")
 	}
 	if len(p.Token) > 0 {
 		viper.Set("gitToken", p.Token)
+		common.Logger.Info("The gitToken has been set")
 	}
 	if len(p.GitURL) > 0 {
 		viper.Set("gitURL", p.GitURL)
+		common.Logger.Info("The gitUrl has been set")
+	}
+	if p.PromptForSecrets {
+		if c.PromptForSecrets {
+			viper.Set("promptForSecrets", false)
+			common.Logger.Info("The promptForSecrets default has been set to false")
+		} else {
+			viper.Set("promptForSecrets", true)
+			common.Logger.Info("The promptForSecrets default has been set to true")
+		}
 	}
 	verr := viper.WriteConfig()
 	if verr != nil {
@@ -72,4 +86,5 @@ func init() {
 	gitconfigCmd.Flags().StringVar(&p.TokenVar, "tokenvar", "", "Set the name of the ENV VAR that contains your git personal token")
 	gitconfigCmd.Flags().StringVar(&p.Token, "token", "", "Set your git personal token")
 	gitconfigCmd.Flags().StringVar(&p.GitURL, "giturl", "", "Set the URL for the repository for upstream utils")
+	gitconfigCmd.Flags().BoolVar(&p.PromptForSecrets, "secrets", false, "Toggle the Prompt for Secrets default")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,7 @@ type (
 		GitToken           string
 		GitUpstream        gitupstream.GitUpstream
 		GitURL             string
+		PromptForSecrets   bool
 	}
 
 	Outputtable interface {

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -22,6 +22,7 @@ type KubernetesClient interface {
 	GetNamespaces() *v1.NamespaceList
 	GetNodes() *v1.NodeList
 	GetServiceAccounts(namespace string) *v1.ServiceAccountList
+	GetSecrets(namespace string) *v1.SecretList
 	DeletePod(pod ask.PodDetail) error
 	DetermineNamespace(nsParam string) string
 }

--- a/kubernetes/secrets.go
+++ b/kubernetes/secrets.go
@@ -1,0 +1,23 @@
+package kubernetes
+
+import (
+	"context"
+	"ktrouble/common"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (k *kubernetesClient) GetSecrets(namespace string) *v1.SecretList {
+	ss := k.Client.CoreV1().Secrets(namespace)
+	secretList, err := ss.List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		common.Logger.WithError(err).Error("could not get list of secrets")
+		return &v1.SecretList{}
+	}
+	if len(secretList.Items) == 0 {
+		common.Logger.Errorf("no secrets were found in namespace: %s", namespace)
+		return &v1.SecretList{}
+	}
+	return secretList
+}

--- a/template/template.go
+++ b/template/template.go
@@ -29,7 +29,7 @@ metadata:
     app: ktrouble
 spec:
   containers:
-  - name: {{ $.Parameters.name}}
+  - name: {{ $.Parameters.name }}
     image: {{ $.Parameters.registry }}
     command:
       - sleep
@@ -42,10 +42,27 @@ spec:
       requests:
         cpu: {{ $.Parameters.requestCpu }}
         memory: {{ $.Parameters.requestMem }}
+    {{- if $.Secrets }}
+    volumeMounts:
+    {{- range $.Secrets }}
+    - mountPath: "/secrets/{{ . }}"
+      name: ktrouble-{{ . }}
+      readOnly: true
+    {{- end }}
+    {{- end }}
   {{- if eq $.Parameters.hasSelector "true" }}
   nodeSelector:
     {{ $.Parameters.selector }}
   {{- end }}
   serviceAccount: {{ $.Parameters.serviceAccount}}
   restartPolicy: Always
+  {{- if $.Secrets }}
+  volumes:
+  {{- range $.Secrets }}
+  - name: ktrouble-{{ . }}
+    secret:
+      defaultMode: 420
+      secretName: {{ . }}
+  {{- end }}
+  {{- end }}
 `))


### PR DESCRIPTION
## Description

Today we had a discussion in which we needed to use a value in a secret in our troubleshooting POD.  

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [x] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

### Additions

- Added a `config.yaml` setting `promptForSecrets` to set the default behavior
- Added a `--secrets` switch to the `set config` command, which will toggle the above setting
- Added a `--secrets` switch to the `launch` command, forcing a prompt of secrets to be mounted
- Secrets are mounted at `/secrets/<secret-name> (dir)/<secret_key (file)>`

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes
