### PR TITLE
Add the ability to select configmaps to mount

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -1,4 +1,4 @@
-time="2023-03-07T22:11:30-06:00" level=error msg="Failed to build KUBECONFIG" error="invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable"
+time="2023-03-07T23:01:04-06:00" level=error msg="Failed to build KUBECONFIG" error="invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable"
 # ktrouble help for all commands
 
 ## TOC
@@ -454,6 +454,7 @@ Aliases:
   launch, create, apply, pod, l
 
 Flags:
+      --configs   Use this switch to prompt to mount configmaps in the POD
       --secrets   Use this switch to prompt to mount secrets in the POD
 
 Global Flags:
@@ -617,6 +618,7 @@ Usage:
   ktrouble set config [flags]
 
 Flags:
+      --configs           Toggle the Prompt for ConfigMaps default
       --giturl string     Set the URL for the repository for upstream utils
       --secrets           Toggle the Prompt for Secrets default
       --token string      Set your git personal token

--- a/README.md
+++ b/README.md
@@ -8,12 +8,82 @@ A CLI tool for launching troubleshooting docker images into a kubernetes cluster
 brew install maahsome/tap/ktrouble --formula
 ```
 
+## Getting Started
+
+Once you have `ktrouble` installed, here are the quick getting running steps:
+
+```zsh
+# run version command, really any command, will build the default `config.yaml` file
+ktrouble version
+# at this point you can run quite a few commands as long as you are connected
+# to a kubernetes cluster (current context)
+# this will list the utilities stored in the `config.yaml` file
+ktrouble get utility
+# this command will prompt to launch a utility
+ktrouble launch       # also ktrouble l
+# adding a new locally defined utility pod
+ktrouble add utility -u helm-kubectl311 -c "/bin/bash" -r "dtzar/helm-kubectl:3.11"
+# modifying an item to keep from prompting to upload on push
+ktrouble update utility -u helm-kubectl311 --toggle-exclude
+# modify an item to change the command
+ktrouble update utility -u helm-kubectl311 -c '/bin/sh'
+# remove a local item
+ktrouble remove utility -u helm-kubectl311
+# hide an item that has an upstream source 'ktrouble-utils' repository
+# this will remove the item from the prompt when using 'ktrouble launch'
+ktrouble remove utility -u alpine3
+ktrouble update utility -u alpine3 --toggle-hidden
+
+# Interactions with 'futurama/farnsworth/tools/ktrouble-utils' repository
+# setup the git credentials
+# if you have an environment variable that contains the token, eg. GITLAB_TOKEN
+ktrouble set config --tokenvar GITHUB_TOKEN --user christopher.maahs
+# if you would rather store the token in the config.yaml file
+ktrouble set config --token "<your token>" --user christopher.maahs
+
+# once configured, you can run the commands to interact with the repository
+# to pull new items into your local config.yaml file
+# this will display a list of utility definitions not already in your local config
+ktrouble pull
+# a status of utility definitions
+ktrouble status
+# to pull items that are listed as "different"
+ktrouble pull -a
+# to get a verbose listing of definitions
+ktrouble get util -f ktrouble get util -f name,repository,exec,hidden,excluded,source
+
+# and or course
+ktrouble --help
+```
+
+## Methodology Change
+
+Originally just running `ktrouble` would start the prompt process.  This required
+breaking the cobra methodologies which resulted in the `--help` features not being
+built correctly.  Usage discovery through `--help` is an important feature to me, so
+I have refactored to using a command to start the launching process `ktrouble launch`
+or shortcut `ktrouble l`.
+
+## Sharing of Utility Definitions
+
+I figure there may as well be an easy way to share definitions.  So some commands
+will be added to assist with CRUD operations on the local `config.yaml` file for
+utility definitions.  Then `push|pull|status` commands will be added that will
+interact with a git repository where a list of utility pod definitions will be
+stored.  The initial population of the `config.yaml` utility definitions will
+also attempt to pull from the central repository before defaulting to the defaults
+in the `defaults` package in the code.
+
 ## PERSONAL JIRA LIST
 
 ```zsh
 switch-jira kt
 jira readme
 ```
+
+### In Flight
+
+- [ ] KT-16:  Start adding godoc comments (In Progress)
 
 ### To Do
 
@@ -22,12 +92,10 @@ jira readme
 - [ ] KT-8:   In the delete command, when no pods are running, exit with that description
 - [ ] KT-9:   Extend the delete command to look at the first param after delete and use that as the delete POD name
 - [ ] KT-10:  Fix a bug where the utilitydefinitions are detected as empty, and defaults are written to config.yaml
-- [ ] KT-16:  Start adding godoc comments (In Progress)
 - [ ] KT-18:  Add command line parameters to the launch command
 - [ ] KT-29:  Add rebase command to pull ALL remote items, overwriting local versions
 - [ ] KT-31:  Sort the LISTS, all of them
 - [ ] KT-32:  Add a description/tools field, to house what tools/operation the utility definition is meant to solve
-- [ ] KT-33:  Fix the conflict between global -f/--fields and genhelp specific -f/--format (In Progress)
 - [ ] KT-34:  Make the delete command MUTLI_SELECT
 - [ ] KT-35:  Add modify alias to the update command
 - [ ] KT-36:  Allow the ability to pass in a set of labels to set for the POD
@@ -35,27 +103,30 @@ jira readme
 
 ### Done
 
-- [x] KT-4:   Add a LIST for running PODs 
-- [x] KT-5:   Add a LIST for defined container images 
-- [x] KT-2:   Move container list details to config.yaml, create an initial version 
-- [x] KT-12:  Add a basic-tools image combining some of the others 
-- [x] KT-6:   Convert to real OUTPUT formats 
-- [x] KT-11:  Read the utilitydefinitions into a global variable rather than re-read config all the time (both MAP and ARRAY) 
-- [x] KT-7:   Replace logrus with common.Logger 
-- [x] KT-13:  Add a bash:// column to the get pods output 
-- [x] KT-14:  Add get sizes to display the request/limits for each size 
-- [x] KT-15:  Turn off auto-format for headers, change header names 
-- [x] KT-17:  Refactor for clarity 
-- [x] KT-19:  Add an add command to add a utility definition 
-- [x] KT-27:  Update the update of the "source" property, so that it only changes ones that are "" blank AND also in the "default" list, and setting all others to "local" 
-- [x] KT-21:  Add a remove command to remove an existing utility definition 
-- [x] KT-22:  Add a local property "excludeFromShare" to exclude an item from being pushed 
-- [x] KT-23:  Add a "source" property, indicating if a utility object is from the upstream source 
-- [x] KT-20:  Add an update command to update an existing utility definition 
-- [x] KT-24:  Add a pull command to display a list of utilities that are on the upstream source, but not downloaded locally, allow an "All" or "multi-select" to choose which to pull 
-- [x] KT-28:  Add set gituser, set gittokenvar, and set gittoken to facilitate setting these config.yaml settings for interation with git 
-- [x] KT-26:  Add a status command that will compare your local config.yaml definitions with the upstream source 
-- [x] KT-25:  Add a push command to push items that are not marked as "excludeFromShare" 
-- [x] KT-30:  Add --all to pull command, to prompt to select from ALL upstream utilities to pull from 
-- [x] KT-38:  Add git URL to set config and consume in the git operations 
+- [x] KT-4:   Add a LIST for running PODs
+- [x] KT-5:   Add a LIST for defined container images
+- [x] KT-2:   Move container list details to config.yaml, create an initial version
+- [x] KT-12:  Add a basic-tools image combining some of the others
+- [x] KT-6:   Convert to real OUTPUT formats
+- [x] KT-11:  Read the utilitydefinitions into a global variable rather than re-read config all the time (both MAP and ARRAY)
+- [x] KT-7:   Replace logrus with common.Logger
+- [x] KT-13:  Add a bash:// column to the get pods output
+- [x] KT-14:  Add get sizes to display the request/limits for each size
+- [x] KT-15:  Turn off auto-format for headers, change header names
+- [x] KT-17:  Refactor for clarity
+- [x] KT-19:  Add an add command to add a utility definition
+- [x] KT-27:  Update the update of the "source" property, so that it only changes ones that are "" blank AND also in the "default" list, and setting all others to "local"
+- [x] KT-21:  Add a remove command to remove an existing utility definition
+- [x] KT-22:  Add a local property "excludeFromShare" to exclude an item from being pushed
+- [x] KT-23:  Add a "source" property, indicating if a utility object is from the upstream source
+- [x] KT-20:  Add an update command to update an existing utility definition
+- [x] KT-24:  Add a pull command to display a list of utilities that are on the upstream source, but not downloaded locally, allow an "All" or "multi-select" to choose which to pull
+- [x] KT-28:  Add set gituser, set gittokenvar, and set gittoken to facilitate setting these config.yaml settings for interation with git
+- [x] KT-26:  Add a status command that will compare your local config.yaml definitions with the upstream source
+- [x] KT-25:  Add a push command to push items that are not marked as "excludeFromShare"
+- [x] KT-30:  Add --all to pull command, to prompt to select from ALL upstream utilities to pull from
+- [x] KT-38:  Add git URL to set config and consume in the git operations
+- [x] KT-39:  Add the ability to prompt for mounting multiple secrets with "--secrets"
+- [x] KT-40:  Add the ability to prompt for mounting multiple configmaps with "--configs"
+- [x] KT-33:  Fix the conflict between global -f/--fields and genhelp specific -f/--format
 

--- a/ask/mount_configmaps.go
+++ b/ask/mount_configmaps.go
@@ -1,0 +1,44 @@
+package ask
+
+import (
+	"os"
+	"sort"
+
+	"ktrouble/common"
+
+	"github.com/AlecAivazis/survey/v2"
+	v1 "k8s.io/api/core/v1"
+)
+
+type (
+	MountConfigMapsAnswer struct {
+		ConfigMap []string `survey:"configmap"`
+	}
+)
+
+func PromptForConfigMaps(configmapList *v1.ConfigMapList) []string {
+
+	var cmArray []string
+	for _, v := range configmapList.Items {
+		cmArray = append(cmArray, v.Name)
+	}
+	sort.Strings(cmArray)
+
+	var cmSurvey = []*survey.Question{
+		{
+			Name: "configmap",
+			Prompt: &survey.MultiSelect{
+				Message: "Choose the configmaps to mount in the POD:",
+				Options: cmArray,
+			},
+		},
+	}
+
+	opts := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
+
+	cmAnswer := &MountConfigMapsAnswer{}
+	if err := survey.Ask(cmSurvey, cmAnswer, opts); err != nil {
+		common.Logger.WithError(err).Fatal("No configmaps selected")
+	}
+	return cmAnswer.ConfigMap
+}

--- a/ask/mount_secrets.go
+++ b/ask/mount_secrets.go
@@ -38,7 +38,7 @@ func PromptForSecrets(secretList *v1.SecretList) []string {
 
 	secretAnswer := &MountSecretsAnswer{}
 	if err := survey.Ask(secretSurvey, secretAnswer, opts); err != nil {
-		common.Logger.WithError(err).Fatal("No service account selected")
+		common.Logger.WithError(err).Fatal("No secrets selected")
 	}
 	return secretAnswer.Secret
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -344,6 +344,18 @@ func initConfig() {
 		}
 	}
 
+	// PromptForConfigMaps
+	if viper.IsSet("promptForConfigMaps") {
+		c.PromptForConfigMaps = viper.GetBool("promptForConfigMaps")
+	} else {
+		// Set the default
+		viper.Set("promptForConfigMaps", false)
+		c.PromptForConfigMaps = false
+		verr := viper.WriteConfig()
+		if verr != nil {
+			logrus.WithError(verr).Info("Failed to write config")
+		}
+	}
 }
 
 // whichSource returns 'ktrouble-utils' if the utility name is in the default list

--- a/cmd/set/set_config.go
+++ b/cmd/set/set_config.go
@@ -9,11 +9,12 @@ import (
 )
 
 type configUserParam struct {
-	Name             string
-	TokenVar         string
-	Token            string
-	GitURL           string
-	PromptForSecrets bool
+	Name                string
+	TokenVar            string
+	Token               string
+	GitURL              string
+	PromptForSecrets    bool
+	PromptForConfigMaps bool
 }
 
 var p configUserParam
@@ -71,6 +72,15 @@ func saveConfig() error {
 			common.Logger.Info("The promptForSecrets default has been set to true")
 		}
 	}
+	if p.PromptForConfigMaps {
+		if c.PromptForConfigMaps {
+			viper.Set("promptForConfigMaps", false)
+			common.Logger.Info("The promptForConfigMaps default has been set to false")
+		} else {
+			viper.Set("promptForConfigMaps", true)
+			common.Logger.Info("The promptForConfigMaps default has been set to true")
+		}
+	}
 	verr := viper.WriteConfig()
 	if verr != nil {
 		common.Logger.WithError(verr).Info("Failed to write config")
@@ -87,4 +97,5 @@ func init() {
 	gitconfigCmd.Flags().StringVar(&p.Token, "token", "", "Set your git personal token")
 	gitconfigCmd.Flags().StringVar(&p.GitURL, "giturl", "", "Set the URL for the repository for upstream utils")
 	gitconfigCmd.Flags().BoolVar(&p.PromptForSecrets, "secrets", false, "Toggle the Prompt for Secrets default")
+	gitconfigCmd.Flags().BoolVar(&p.PromptForConfigMaps, "configs", false, "Toggle the Prompt for ConfigMaps default")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -10,31 +10,32 @@ import (
 
 type (
 	Config struct {
-		VersionDetail      objects.Version
-		VersionJSON        string
-		OutputFormat       string
-		FormatOverridden   bool
-		NoHeaders          bool
-		CACert             string
-		CABundle           string
-		LogLevel           string
-		LogFile            string
-		Namespace          string
-		EnableBashLinks    bool
-		UniqIdLength       int
-		ShowHidden         bool
-		UtilMap            map[string]objects.UtilityPod
-		UtilDefs           objects.UtilityPodList
-		SizeMap            map[string]objects.ResourceSize
-		SizeDefs           objects.ResourceSizeList
-		NodeSelectorLabels []string
-		Client             kubernetes.KubernetesClient
-		Fields             []string
-		GitUser            string
-		GitToken           string
-		GitUpstream        gitupstream.GitUpstream
-		GitURL             string
-		PromptForSecrets   bool
+		VersionDetail       objects.Version
+		VersionJSON         string
+		OutputFormat        string
+		FormatOverridden    bool
+		NoHeaders           bool
+		CACert              string
+		CABundle            string
+		LogLevel            string
+		LogFile             string
+		Namespace           string
+		EnableBashLinks     bool
+		UniqIdLength        int
+		ShowHidden          bool
+		UtilMap             map[string]objects.UtilityPod
+		UtilDefs            objects.UtilityPodList
+		SizeMap             map[string]objects.ResourceSize
+		SizeDefs            objects.ResourceSizeList
+		NodeSelectorLabels  []string
+		Client              kubernetes.KubernetesClient
+		Fields              []string
+		GitUser             string
+		GitToken            string
+		GitUpstream         gitupstream.GitUpstream
+		GitURL              string
+		PromptForSecrets    bool
+		PromptForConfigMaps bool
 	}
 
 	Outputtable interface {

--- a/kubernetes/configmaps.go
+++ b/kubernetes/configmaps.go
@@ -1,0 +1,23 @@
+package kubernetes
+
+import (
+	"context"
+	"ktrouble/common"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (k *kubernetesClient) GetConfigMaps(namespace string) *v1.ConfigMapList {
+	cm := k.Client.CoreV1().ConfigMaps(namespace)
+	configmapList, err := cm.List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		common.Logger.WithError(err).Error("could not get list of secrets")
+		return &v1.ConfigMapList{}
+	}
+	if len(configmapList.Items) == 0 {
+		common.Logger.Errorf("no configmaps were found in namespace: %s", namespace)
+		return &v1.ConfigMapList{}
+	}
+	return configmapList
+}

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -23,6 +23,7 @@ type KubernetesClient interface {
 	GetNodes() *v1.NodeList
 	GetServiceAccounts(namespace string) *v1.ServiceAccountList
 	GetSecrets(namespace string) *v1.SecretList
+	GetConfigMaps(namespace string) *v1.ConfigMapList
 	DeletePod(pod ask.PodDetail) error
 	DetermineNamespace(nsParam string) string
 }

--- a/template/template.go
+++ b/template/template.go
@@ -42,11 +42,20 @@ spec:
       requests:
         cpu: {{ $.Parameters.requestCpu }}
         memory: {{ $.Parameters.requestMem }}
-    {{- if $.Secrets }}
+    {{- if or $.Secrets $.ConfigMaps }}
     volumeMounts:
+    {{- end }}
+    {{- if $.Secrets }}
     {{- range $.Secrets }}
     - mountPath: "/secrets/{{ . }}"
       name: ktrouble-{{ . }}
+      readOnly: true
+    {{- end }}
+    {{- end }}
+    {{- if $.ConfigMaps }}
+    {{- range $.ConfigMaps }}
+    - mountPath: "/configmaps/{{ .}}"
+      name: ktrouble-cm-{{ . }}
       readOnly: true
     {{- end }}
     {{- end }}
@@ -56,13 +65,23 @@ spec:
   {{- end }}
   serviceAccount: {{ $.Parameters.serviceAccount}}
   restartPolicy: Always
-  {{- if $.Secrets }}
+  {{- if or $.Secrets $.ConfigMaps }}
   volumes:
+  {{- end }}
+  {{- if $.Secrets }}
   {{- range $.Secrets }}
   - name: ktrouble-{{ . }}
     secret:
       defaultMode: 420
       secretName: {{ . }}
+  {{- end }}
+  {{- end }}
+  {{- if $.ConfigMaps }}
+  {{- range $.ConfigMaps }}
+  - name: ktrouble-cm-{{ .}}
+    configMap:
+      defaultMode: 420
+      name: {{ . }}
   {{- end }}
   {{- end }}
 `))


### PR DESCRIPTION
## Description

Today we had a discussion in which we needed to use a value in a secret in our troubleshooting POD, so naturally, configmaps too.

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [x] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

### Additions

- Added a `config.yaml` setting `promptForConfigMaps` to set the default behavior
- Added a `--configs` switch to the `set config` command, which will toggle the above setting
- Added a `--configs` switch to the `launch` command, forcing a prompt of configmaps to be mounted
- Secrets are mounted at `/configmaps/<configmap-name> (dir)/<configmap_key (file)>`

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes
