### PR TITLE
Add a templates dir in config dir, populate with default and consume

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -1,4 +1,4 @@
-time="2023-03-07T23:01:04-06:00" level=error msg="Failed to build KUBECONFIG" error="invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable"
+time="2023-03-08T08:28:40-06:00" level=error msg="Failed to build KUBECONFIG" error="invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable"
 # ktrouble help for all commands
 
 ## TOC
@@ -71,6 +71,7 @@ Flags:
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
   -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+  -t, --template string    Specify the template file to use to render the POD manifest (default "default")
 
 Use "ktrouble [command] --help" for more information about a command.
 ```
@@ -99,6 +100,7 @@ Global Flags:
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
   -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+  -t, --template string    Specify the template file to use to render the POD manifest (default "default")
 
 Use "ktrouble add [command] --help" for more information about a command.
 ```
@@ -126,6 +128,7 @@ Global Flags:
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
   -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+  -t, --template string    Specify the template file to use to render the POD manifest (default "default")
 ```
 
 [TOC](#TOC)
@@ -151,6 +154,7 @@ Global Flags:
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
   -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+  -t, --template string    Specify the template file to use to render the POD manifest (default "default")
 ```
 
 [TOC](#TOC)
@@ -172,6 +176,7 @@ Global Flags:
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
   -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+  -t, --template string    Specify the template file to use to render the POD manifest (default "default")
 ```
 
 [TOC](#TOC)
@@ -223,6 +228,7 @@ Global Flags:
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
   -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+  -t, --template string    Specify the template file to use to render the POD manifest (default "default")
 
 Use "ktrouble get [command] --help" for more information about a command.
 ```
@@ -252,6 +258,7 @@ Global Flags:
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
   -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+  -t, --template string    Specify the template file to use to render the POD manifest (default "default")
 ```
 
 [TOC](#TOC)
@@ -279,6 +286,7 @@ Global Flags:
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
   -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+  -t, --template string    Specify the template file to use to render the POD manifest (default "default")
 ```
 
 [TOC](#TOC)
@@ -306,6 +314,7 @@ Global Flags:
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
   -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+  -t, --template string    Specify the template file to use to render the POD manifest (default "default")
 ```
 
 [TOC](#TOC)
@@ -342,6 +351,7 @@ Global Flags:
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
   -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+  -t, --template string    Specify the template file to use to render the POD manifest (default "default")
 ```
 
 [TOC](#TOC)
@@ -375,6 +385,7 @@ Global Flags:
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
   -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+  -t, --template string    Specify the template file to use to render the POD manifest (default "default")
 ```
 
 [TOC](#TOC)
@@ -402,6 +413,7 @@ Global Flags:
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
   -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+  -t, --template string    Specify the template file to use to render the POD manifest (default "default")
 ```
 
 [TOC](#TOC)
@@ -429,6 +441,7 @@ Global Flags:
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
   -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+  -t, --template string    Specify the template file to use to render the POD manifest (default "default")
 ```
 
 [TOC](#TOC)
@@ -466,6 +479,7 @@ Global Flags:
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
   -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+  -t, --template string    Specify the template file to use to render the POD manifest (default "default")
 ```
 
 [TOC](#TOC)
@@ -491,6 +505,7 @@ Global Flags:
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
   -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+  -t, --template string    Specify the template file to use to render the POD manifest (default "default")
 ```
 
 [TOC](#TOC)
@@ -513,6 +528,7 @@ Global Flags:
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
   -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+  -t, --template string    Specify the template file to use to render the POD manifest (default "default")
 ```
 
 [TOC](#TOC)
@@ -539,6 +555,7 @@ Global Flags:
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
   -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+  -t, --template string    Specify the template file to use to render the POD manifest (default "default")
 
 Use "ktrouble remove [command] --help" for more information about a command.
 ```
@@ -565,6 +582,7 @@ Global Flags:
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
   -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+  -t, --template string    Specify the template file to use to render the POD manifest (default "default")
 ```
 
 [TOC](#TOC)
@@ -591,6 +609,7 @@ Global Flags:
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
   -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+  -t, --template string    Specify the template file to use to render the POD manifest (default "default")
 
 Use "ktrouble set [command] --help" for more information about a command.
 ```
@@ -618,6 +637,7 @@ Usage:
   ktrouble set config [flags]
 
 Flags:
+      --bashlinks         Toggle the use of Bash Links for iTerm2
       --configs           Toggle the Prompt for ConfigMaps default
       --giturl string     Set the URL for the repository for upstream utils
       --secrets           Toggle the Prompt for Secrets default
@@ -634,6 +654,7 @@ Global Flags:
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
   -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+  -t, --template string    Specify the template file to use to render the POD manifest (default "default")
 ```
 
 [TOC](#TOC)
@@ -656,6 +677,7 @@ Global Flags:
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
   -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+  -t, --template string    Specify the template file to use to render the POD manifest (default "default")
 ```
 
 [TOC](#TOC)
@@ -682,6 +704,7 @@ Global Flags:
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
   -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+  -t, --template string    Specify the template file to use to render the POD manifest (default "default")
 
 Use "ktrouble update [command] --help" for more information about a command.
 ```
@@ -710,6 +733,7 @@ Global Flags:
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
   -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+  -t, --template string    Specify the template file to use to render the POD manifest (default "default")
 ```
 
 [TOC](#TOC)
@@ -731,6 +755,7 @@ Global Flags:
       --no-headers         Suppress header output in Text output
   -o, --output string      output types: json, text, yaml, gron, raw
   -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+  -t, --template string    Specify the template file to use to render the POD manifest (default "default")
 ```
 
 [TOC](#TOC)

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ jira readme
 - [ ] KT-35:  Add modify alias to the update command
 - [ ] KT-36:  Allow the ability to pass in a set of labels to set for the POD
 - [ ] KT-37:  On genhelp, don't require kube context to be configured
+- [ ] KT-42:  Add edit config
+- [ ] KT-43:  Add edit template
+- [ ] KT-44:  Add KTROUBLE_CONFIG ENV variable override of config.yaml file
 
 ### Done
 
@@ -129,4 +132,4 @@ jira readme
 - [x] KT-39:  Add the ability to prompt for mounting multiple secrets with "--secrets"
 - [x] KT-40:  Add the ability to prompt for mounting multiple configmaps with "--configs"
 - [x] KT-33:  Fix the conflict between global -f/--fields and genhelp specific -f/--format
-
+- [x] KT-41:  Improve template feature

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bytes"
 	"fmt"
 	"math/rand"
 
@@ -19,12 +18,6 @@ type launchParam struct {
 }
 
 var p launchParam
-
-type TemplateConfig struct {
-	Parameters map[string]string
-	Secrets    []string
-	ConfigMaps []string
-}
 
 var letters = []rune("abcdef0987654321")
 
@@ -97,7 +90,7 @@ EXAMPLE:
 			}
 
 			shortUniq := randSeq(c.UniqIdLength)
-			tc := &TemplateConfig{
+			tc := &template.TemplateConfig{
 				Parameters: map[string]string{
 					"name":           fmt.Sprintf("%s-%s", utility, shortUniq),
 					"serviceAccount": sa,
@@ -114,13 +107,9 @@ EXAMPLE:
 				ConfigMaps: selectedConfigMaps,
 			}
 
-			var tpl bytes.Buffer
-			if err := template.ApplicationsTemplate.Execute(&tpl, tc); err != nil {
-				common.Logger.WithError(err).Error("unable to generate the template data")
-			}
-
-			podManifest := tpl.String()
-
+			common.Logger.Debugf("Template file: %s", c.TemplateFile)
+			tp := template.New(c.TemplateFile)
+			podManifest := tp.RenderTemplate(tc)
 			common.Logger.Debugf("Manifest: \n%s\n", podManifest)
 			c.Client.CreatePod(podManifest, namespace)
 

--- a/cmd/set/set_config.go
+++ b/cmd/set/set_config.go
@@ -15,6 +15,7 @@ type configUserParam struct {
 	GitURL              string
 	PromptForSecrets    bool
 	PromptForConfigMaps bool
+	EnableBashLinks     bool
 }
 
 var p configUserParam
@@ -47,23 +48,29 @@ EXAMPLE:
 
 func saveConfig() error {
 
+	itemsChanged := false
 	if len(p.Name) > 0 {
 		viper.Set("gitUser", p.Name)
 		common.Logger.Info("The gitUser has been set")
+		itemsChanged = true
 	}
 	if len(p.TokenVar) > 0 {
 		viper.Set("gitTokenVar", p.TokenVar)
 		common.Logger.Info("The gitTokenVar has been set")
+		itemsChanged = true
 	}
 	if len(p.Token) > 0 {
 		viper.Set("gitToken", p.Token)
 		common.Logger.Info("The gitToken has been set")
+		itemsChanged = true
 	}
 	if len(p.GitURL) > 0 {
 		viper.Set("gitURL", p.GitURL)
 		common.Logger.Info("The gitUrl has been set")
+		itemsChanged = true
 	}
 	if p.PromptForSecrets {
+		itemsChanged = true
 		if c.PromptForSecrets {
 			viper.Set("promptForSecrets", false)
 			common.Logger.Info("The promptForSecrets default has been set to false")
@@ -73,6 +80,7 @@ func saveConfig() error {
 		}
 	}
 	if p.PromptForConfigMaps {
+		itemsChanged = true
 		if c.PromptForConfigMaps {
 			viper.Set("promptForConfigMaps", false)
 			common.Logger.Info("The promptForConfigMaps default has been set to false")
@@ -81,10 +89,22 @@ func saveConfig() error {
 			common.Logger.Info("The promptForConfigMaps default has been set to true")
 		}
 	}
-	verr := viper.WriteConfig()
-	if verr != nil {
-		common.Logger.WithError(verr).Info("Failed to write config")
-		return verr
+	if p.EnableBashLinks {
+		itemsChanged = true
+		if c.EnableBashLinks {
+			viper.Set("enableBashLinks", false)
+			common.Logger.Info("The enableBashLinks has been set to false")
+		} else {
+			viper.Set("enableBashLinks", true)
+			common.Logger.Info("The enableBashLinks has been set to true")
+		}
+	}
+	if itemsChanged {
+		verr := viper.WriteConfig()
+		if verr != nil {
+			common.Logger.WithError(verr).Info("Failed to write config")
+			return verr
+		}
 	}
 	return nil
 }
@@ -98,4 +118,5 @@ func init() {
 	gitconfigCmd.Flags().StringVar(&p.GitURL, "giturl", "", "Set the URL for the repository for upstream utils")
 	gitconfigCmd.Flags().BoolVar(&p.PromptForSecrets, "secrets", false, "Toggle the Prompt for Secrets default")
 	gitconfigCmd.Flags().BoolVar(&p.PromptForConfigMaps, "configs", false, "Toggle the Prompt for ConfigMaps default")
+	gitconfigCmd.Flags().BoolVar(&p.EnableBashLinks, "bashlinks", false, "Toggle the use of Bash Links for iTerm2")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,7 @@ type (
 		GitURL              string
 		PromptForSecrets    bool
 		PromptForConfigMaps bool
+		TemplateFile        string
 	}
 
 	Outputtable interface {

--- a/defaults/template.go
+++ b/defaults/template.go
@@ -1,0 +1,72 @@
+package defaults
+
+func DefaultTemplate() string {
+	defaultTemplate := `---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ $.Parameters.name }}
+  namespace: {{ $.Parameters.namespace }}
+  labels:
+    app: ktrouble
+spec:
+  containers:
+  - name: {{ $.Parameters.name }}
+    image: {{ $.Parameters.registry }}
+    command:
+      - sleep
+      - "86400"
+    imagePullPolicy: Always
+    resources:
+      limits:
+        cpu: {{ $.Parameters.limitsCpu }}
+        memory: {{ $.Parameters.limitsMem }}
+      requests:
+        cpu: {{ $.Parameters.requestCpu }}
+        memory: {{ $.Parameters.requestMem }}
+    {{- if or $.Secrets $.ConfigMaps }}
+    volumeMounts:
+    {{- end }}
+    {{- if $.Secrets }}
+    {{- range $.Secrets }}
+    - mountPath: "/secrets/{{ . }}"
+      name: ktrouble-{{ . }}
+      readOnly: true
+    {{- end }}
+    {{- end }}
+    {{- if $.ConfigMaps }}
+    {{- range $.ConfigMaps }}
+    - mountPath: "/configmaps/{{ .}}"
+      name: ktrouble-cm-{{ . }}
+      readOnly: true
+    {{- end }}
+    {{- end }}
+  {{- if eq $.Parameters.hasSelector "true" }}
+  nodeSelector:
+    {{ $.Parameters.selector }}
+  {{- end }}
+  serviceAccount: {{ $.Parameters.serviceAccount}}
+  restartPolicy: Always
+  {{- if or $.Secrets $.ConfigMaps }}
+  volumes:
+  {{- end }}
+  {{- if $.Secrets }}
+  {{- range $.Secrets }}
+  - name: ktrouble-{{ . }}
+    secret:
+      defaultMode: 420
+      secretName: {{ . }}
+  {{- end }}
+  {{- end }}
+  {{- if $.ConfigMaps }}
+  {{- range $.ConfigMaps }}
+  - name: ktrouble-cm-{{ .}}
+    configMap:
+      defaultMode: 420
+      name: {{ . }}
+  {{- end }}
+  {{- end }}
+`
+
+	return defaultTemplate
+}

--- a/template/template.go
+++ b/template/template.go
@@ -1,9 +1,27 @@
 package template
 
 import (
+	"bytes"
+	"fmt"
+	"ktrouble/common"
+	"os"
 	"strings"
 	"text/template"
 )
+
+type TemplateProcessor interface {
+	RenderTemplate(tc *TemplateConfig) string
+}
+
+type templateProcessor struct {
+	Tpl string
+}
+
+type TemplateConfig struct {
+	Parameters map[string]string
+	Secrets    []string
+	ConfigMaps []string
+}
 
 // takes in some text and pads it with spaces even if it is multiline
 func indent(spaces int, v string) string {
@@ -17,71 +35,34 @@ var applicationsTemplateFuncs = template.FuncMap{
 	"hasPrefix": strings.HasPrefix,
 }
 
-var ApplicationsTemplate = template.Must(
-	template.New("applications.yaml.tpl").Funcs(applicationsTemplateFuncs).Parse(
-		`---
-apiVersion: v1
-kind: Pod
-metadata:
-  name: {{ $.Parameters.name }}
-  namespace: {{ $.Parameters.namespace }}
-  labels:
-    app: ktrouble
-spec:
-  containers:
-  - name: {{ $.Parameters.name }}
-    image: {{ $.Parameters.registry }}
-    command:
-      - sleep
-      - "86400"
-    imagePullPolicy: Always
-    resources:
-      limits:
-        cpu: {{ $.Parameters.limitsCpu }}
-        memory: {{ $.Parameters.limitsMem }}
-      requests:
-        cpu: {{ $.Parameters.requestCpu }}
-        memory: {{ $.Parameters.requestMem }}
-    {{- if or $.Secrets $.ConfigMaps }}
-    volumeMounts:
-    {{- end }}
-    {{- if $.Secrets }}
-    {{- range $.Secrets }}
-    - mountPath: "/secrets/{{ . }}"
-      name: ktrouble-{{ . }}
-      readOnly: true
-    {{- end }}
-    {{- end }}
-    {{- if $.ConfigMaps }}
-    {{- range $.ConfigMaps }}
-    - mountPath: "/configmaps/{{ .}}"
-      name: ktrouble-cm-{{ . }}
-      readOnly: true
-    {{- end }}
-    {{- end }}
-  {{- if eq $.Parameters.hasSelector "true" }}
-  nodeSelector:
-    {{ $.Parameters.selector }}
-  {{- end }}
-  serviceAccount: {{ $.Parameters.serviceAccount}}
-  restartPolicy: Always
-  {{- if or $.Secrets $.ConfigMaps }}
-  volumes:
-  {{- end }}
-  {{- if $.Secrets }}
-  {{- range $.Secrets }}
-  - name: ktrouble-{{ . }}
-    secret:
-      defaultMode: 420
-      secretName: {{ . }}
-  {{- end }}
-  {{- end }}
-  {{- if $.ConfigMaps }}
-  {{- range $.ConfigMaps }}
-  - name: ktrouble-cm-{{ .}}
-    configMap:
-      defaultMode: 420
-      name: {{ . }}
-  {{- end }}
-  {{- end }}
-`))
+func New(templateFile string) TemplateProcessor {
+	home, herr := os.UserHomeDir()
+	if herr != nil {
+		common.Logger.Error("failed to fetch home directory")
+	}
+	tmplDir := fmt.Sprintf("%s/.config/ktrouble/templates", home)
+
+	templatePath := fmt.Sprintf("%s/%s", tmplDir, templateFile)
+	fileData, err := os.ReadFile(templatePath)
+	if err != nil {
+		common.Logger.WithError(err).Fatal("failed to read the specified template file: %s")
+	}
+	tpl := string(fileData)
+
+	return &templateProcessor{
+		Tpl: tpl,
+	}
+}
+
+func (t *templateProcessor) RenderTemplate(tc *TemplateConfig) string {
+
+	applicationsTemplate := template.Must(
+		template.New("pod.yaml.tpl").Funcs(applicationsTemplateFuncs).Parse(t.Tpl))
+	var tpl bytes.Buffer
+	if err := applicationsTemplate.Execute(&tpl, tc); err != nil {
+		common.Logger.WithError(err).Error("unable to generate the template data")
+	}
+
+	return tpl.String()
+
+}


### PR DESCRIPTION
## Description

Make the template editable by creating and consuming from the config/templates directory

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [x] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

### Additions

- Moved the POD manifest template from code, to a `defaults` object that is written out to the `$HOME/.config/ktrouble/templates` directory as `default`
- This will will be written whenever it doesn't exist
- The `default` template will be loaded from the config directory, so it can be directly modified
- Specify a different template using `--template/-t` with just the name, eg. `ktrouble -l -t cmaahs`
  - will load the `cmaahs` named template from the `$HOME/.config/ktrouble/templates/cmaahs` file
- Added a `--bashlinks` switch to the `set config` command to allow toggling of that config parameter

### Changes

- Removed uses of short switch `-t` in sub-commands, to allow global `--template/-t`

### Fixes

- Some minor improvements and fixes

### Deprecated

### Removed

### Breaking Changes

