### PR TITLE
KT-44, KT-37: use ENV for config file, skip kubeconfig on subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,9 @@ jira readme
 - [ ] KT-34:  Make the delete command MUTLI_SELECT
 - [ ] KT-35:  Add modify alias to the update command
 - [ ] KT-36:  Allow the ability to pass in a set of labels to set for the POD
-- [ ] KT-37:  On genhelp, don't require kube context to be configured
 - [ ] KT-42:  Add edit config
 - [ ] KT-43:  Add edit template
-- [ ] KT-44:  Add KTROUBLE_CONFIG ENV variable override of config.yaml file
+- [ ] KT-45:  Add a "defaultTemplate" setting in the config.yaml, and default to "default", and use that as the template when no --template/-t is provided
 
 ### Done
 
@@ -133,3 +132,5 @@ jira readme
 - [x] KT-40:  Add the ability to prompt for mounting multiple configmaps with "--configs"
 - [x] KT-33:  Fix the conflict between global -f/--fields and genhelp specific -f/--format
 - [x] KT-41:  Improve template feature
+- [x] KT-44:  Add KTROUBLE_CONFIG ENV variable override of config.yaml file
+- [x] KT-37:  On genhelp, don't require kube context to be configured

--- a/cmd/get/get_namespace.go
+++ b/cmd/get/get_namespace.go
@@ -2,6 +2,7 @@ package get
 
 import (
 	"ktrouble/common"
+	"ktrouble/defaults"
 	"ktrouble/objects"
 
 	"github.com/spf13/cobra"
@@ -10,7 +11,7 @@ import (
 // namespaceCmd represents the namespace command
 var namespaceCmd = &cobra.Command{
 	Use:     "namespace",
-	Aliases: []string{"namespaces", "ns"},
+	Aliases: defaults.GetNamespacesAliases,
 	Short:   "Get a list of namespaces",
 	Long: `EXAMPLE:
   Return a list of kubernetes namespaces for the current context cluster

--- a/cmd/get/get_node.go
+++ b/cmd/get/get_node.go
@@ -2,6 +2,7 @@ package get
 
 import (
 	"ktrouble/common"
+	"ktrouble/defaults"
 	"ktrouble/objects"
 
 	"github.com/spf13/cobra"
@@ -10,7 +11,7 @@ import (
 // nodeCmd represents the node command
 var nodeCmd = &cobra.Command{
 	Use:     "node",
-	Aliases: []string{"nodes"},
+	Aliases: defaults.GetNodesAliases,
 	Short:   "Get a list of node labels",
 	Long: `EXAMPLE:
   Get a list of nodes for the current context cluster

--- a/cmd/get/get_nodelabels.go
+++ b/cmd/get/get_nodelabels.go
@@ -1,6 +1,7 @@
 package get
 
 import (
+	"ktrouble/defaults"
 	"ktrouble/objects"
 
 	"github.com/spf13/cobra"
@@ -9,7 +10,7 @@ import (
 // nodelabelsCmd represents the nodelabels command
 var nodelabelsCmd = &cobra.Command{
 	Use:     "nodelabels",
-	Aliases: []string{"nodelabel", "nl", "labels"},
+	Aliases: defaults.GetNodeLabelsAliases,
 	Short:   "Get a list of defined node labels in config.yaml",
 	Long: `EXAMPLE:
   Show the list of node labels in the configuration file

--- a/cmd/get/get_running.go
+++ b/cmd/get/get_running.go
@@ -2,6 +2,7 @@ package get
 
 import (
 	"ktrouble/common"
+	"ktrouble/defaults"
 	"ktrouble/objects"
 
 	"github.com/spf13/cobra"
@@ -10,7 +11,7 @@ import (
 // runningCmd represents the running command
 var runningCmd = &cobra.Command{
 	Use:     "running",
-	Aliases: []string{"pods", "pod"},
+	Aliases: defaults.GetRunningAliases,
 	Short:   "Get a list of running pods",
 	Long: `EXAMPLE:
   Get a list of PODs that are currently running on the current context kubernetes

--- a/cmd/get/get_serviceaccount.go
+++ b/cmd/get/get_serviceaccount.go
@@ -2,6 +2,7 @@ package get
 
 import (
 	"ktrouble/common"
+	"ktrouble/defaults"
 	"ktrouble/objects"
 
 	"github.com/spf13/cobra"
@@ -10,7 +11,7 @@ import (
 // serviceaccountCmd represents the serviceaccount command
 var serviceaccountCmd = &cobra.Command{
 	Use:     "serviceaccount",
-	Aliases: []string{"serviceaccounts", "sa"},
+	Aliases: defaults.GetServiceAccountsAliases,
 	Short:   "Get a list of K8s ServiceAccount(s) in a Namespace",
 	Long: `EXAMPLE:
   Return a list of kubernetes service accounts for a namespace

--- a/cmd/get/get_sizes.go
+++ b/cmd/get/get_sizes.go
@@ -1,6 +1,7 @@
 package get
 
 import (
+	"ktrouble/defaults"
 	"ktrouble/objects"
 
 	"github.com/spf13/cobra"
@@ -9,7 +10,7 @@ import (
 // sizesCmd represents the sizes command
 var sizesCmd = &cobra.Command{
 	Use:     "sizes",
-	Aliases: []string{"size", "requests", "request", "limit", "limits"},
+	Aliases: defaults.GetSizesAliases,
 	Short:   "Get a list of defined sizes",
 	Long: `EXAMPLE:
   Display a list of POD size options from the configuration file

--- a/cmd/get/get_utilities.go
+++ b/cmd/get/get_utilities.go
@@ -1,6 +1,7 @@
 package get
 
 import (
+	"ktrouble/defaults"
 	"ktrouble/objects"
 
 	"github.com/spf13/cobra"
@@ -9,7 +10,7 @@ import (
 // utilitiesCmd represents the utilities command
 var utilitiesCmd = &cobra.Command{
 	Use:     "utilities",
-	Aliases: []string{"utility", "utils", "util", "container", "containers", "image", "images"},
+	Aliases: defaults.GetUtilitesAliases,
 	Short:   "Get a list of supported utility container images",
 	Long: `EXAMPLE:
   Display a list of utilities defined in the configuration file

--- a/defaults/constants.go
+++ b/defaults/constants.go
@@ -1,0 +1,9 @@
+package defaults
+
+var GetUtilitesAliases = []string{"utility", "utils", "util", "container", "containers", "image", "images"}
+var GetNamespacesAliases = []string{"namespaces", "ns"}
+var GetNodesAliases = []string{"nodes"}
+var GetNodeLabelsAliases = []string{"nodelabel", "nl", "labels"}
+var GetRunningAliases = []string{"pods", "pod"}
+var GetServiceAccountsAliases = []string{"serviceaccounts", "sa"}
+var GetSizesAliases = []string{"size", "requests", "request", "limit", "limits"}


### PR DESCRIPTION
## Description

Add KTROUBLE_CONFIG environment variable support to define the config file

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [x] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

### Additions

- Enable using `KTROUBLE_CONFIG` to specify the `config.yaml` file to use
  - `export KTROUBLE_CONFIG=cmaahs-config.yaml`

### Changes

- Only initialize the kubernetes context when required
  - streamline various parts of the code surrounding this

### Fixes

### Deprecated

### Removed

### Breaking Changes
