### PR TITLE
Add edit config and get configs commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,8 @@ jira readme
 - [ ] KT-34:  Make the delete command MUTLI_SELECT
 - [ ] KT-35:  Add modify alias to the update command
 - [ ] KT-36:  Allow the ability to pass in a set of labels to set for the POD
-- [ ] KT-42:  Add edit config
 - [ ] KT-45:  Add a "defaultTemplate" setting in the config.yaml, and default to "default", and use that as the template when no --template/-t is provided
 - [ ] KT-47:  Remove -n from the description of the --name parameter for add utility
-- [ ] KT-48:  Fix pipeline to include the latest changelog file
 
 ### Done
 
@@ -137,4 +135,6 @@ jira readme
 - [x] KT-37:  On genhelp, don't require kube context to be configured
 - [x] KT-46:  Add a compile time variable to hold the git address where the CHANGELOG entries are. Add a changelog command, this command will fetch the related vN.N.N.md file and spit it out. Also will take --version vN.N.N and --select to prompt
 - [x] KT-43:  Add edit template
+- [x] KT-48:  Fix pipeline to include the latest changelog file
+- [x] KT-42:  Add edit config
 

--- a/cmd/edit/edit.go
+++ b/cmd/edit/edit.go
@@ -6,6 +6,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	chunksize int = 1024
+)
+
 var editCmd = &cobra.Command{
 	Use:   "edit",
 	Args:  cobra.MinimumNArgs(1),

--- a/cmd/edit/edit_config.go
+++ b/cmd/edit/edit_config.go
@@ -1,0 +1,65 @@
+package edit
+
+import (
+	"bytes"
+	"fmt"
+	"ktrouble/common"
+	"os"
+
+	"github.com/spf13/cobra"
+	"k8s.io/kubectl/pkg/cmd/util/editor"
+)
+
+// configCmd represents the config command
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Edit the default config, or specified in KTROUBLE_CONFIG",
+	Long: `EXAMPLE
+  > ktrouble edit config
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		editConfig()
+	},
+}
+
+func editConfig() {
+	edit := editor.NewDefaultEditor([]string{
+		"KTROUBLE_EDITOR",
+		"EDITOR",
+	})
+	home, herr := os.UserHomeDir()
+	if herr != nil {
+		common.Logger.WithError(herr).Error("failed to determine the HOME directory")
+	}
+	confDir := fmt.Sprintf("%s/.config/ktrouble", home)
+	fileToOpen := fmt.Sprintf("%s/config.yaml", confDir)
+	envCfgFile := os.Getenv("KTROUBLE_CONFIG")
+	if envCfgFile != "" {
+		fileToOpen = fmt.Sprintf("%s/%s", confDir, envCfgFile)
+	}
+
+	_, buffer := openFile(fileToOpen)
+
+	original := buffer.Bytes()
+
+	edited, _, err := edit.LaunchTempFile("ktrouble-config", ".yaml", buffer)
+	if err != nil {
+		common.Logger.WithError(err).Error("failed to exit the editor cleanly")
+	}
+
+	if bytes.Equal(edited, original) {
+		common.Logger.Info("no changes detected")
+	} else {
+		err := os.WriteFile(fileToOpen, edited, 0644)
+		if err != nil {
+			common.Logger.WithError(err).Error("failed to write changes")
+		} else {
+			common.Logger.Info("changes saved")
+		}
+	}
+
+}
+
+func init() {
+	editCmd.AddCommand(configCmd)
+}

--- a/cmd/edit/edit_template.go
+++ b/cmd/edit/edit_template.go
@@ -13,10 +13,6 @@ import (
 	"k8s.io/kubectl/pkg/cmd/util/editor"
 )
 
-const (
-	chunksize int = 1024
-)
-
 // templateCmd represents the template command
 var templateCmd = &cobra.Command{
 	Use:   "template",

--- a/cmd/get/get_configs.go
+++ b/cmd/get/get_configs.go
@@ -1,0 +1,41 @@
+package get
+
+import (
+	"fmt"
+	"ktrouble/common"
+	"ktrouble/defaults"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// configsCmd represents the templates command
+var configsCmd = &cobra.Command{
+	Use:     "configs",
+	Aliases: defaults.GetSizesAliases,
+	Short:   "Get a list of configs",
+	Long: `EXAMPLE:
+  > ktrouble get configs
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		home, herr := os.UserHomeDir()
+		if herr != nil {
+			common.Logger.WithError(herr).Error("failed to determine the HOME directory")
+		}
+		confDir := fmt.Sprintf("%s/.config/ktrouble", home)
+		files, _ := os.ReadDir(confDir)
+		if !c.NoHeaders {
+			fmt.Println("CONFIG")
+		}
+		for _, f := range files {
+			if strings.HasSuffix(f.Name(), ".yaml") {
+				fmt.Printf("%s\n", f.Name())
+			}
+		}
+	},
+}
+
+func init() {
+	getCmd.AddCommand(configsCmd)
+}

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -113,7 +113,11 @@ EXAMPLE:
 			common.Logger.Debugf("Manifest: \n%s\n", podManifest)
 			c.Client.CreatePod(podManifest, namespace)
 
-			fmt.Printf("kubectl -n %s exec -it %s -- %s\n", namespace, fmt.Sprintf("%s-%s", utility, shortUniq), utilMap[utility].ExecCommand)
+			if c.EnableBashLinks {
+				fmt.Printf("<bash:kubectl -n %s exec -it %s -- %s>\n", namespace, fmt.Sprintf("%s-%s", utility, shortUniq), utilMap[utility].ExecCommand)
+			} else {
+				fmt.Printf("kubectl -n %s exec -it %s -- %s\n", namespace, fmt.Sprintf("%s-%s", utility, shortUniq), utilMap[utility].ExecCommand)
+			}
 		} else {
 			common.Logger.Warn("Cannot launch a pod, no valid kubernetes context")
 		}


### PR DESCRIPTION
## Description

Add the ability to quickly open an editor for editing the config file

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Dependencies
<!--- If this fix is dependent on code in other repos to be deployed, list that here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [x] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
- **BREAKING** note on base feature
- Basically whatever formatting we have here, just plain-text
%> command example
- next feature
- note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

- Added an `edit config` that will edit the default or KTROUBLE_CONFIG indicated config file
- Added a `get configs` command to quickly list the config files

### Changes

- Added a check for `enableBashLinks` and output the EXEC command at the end of the launch command in the bash links format

### Fixes

### Deprecated

### Removed

### Breaking Changes

