### PR TITLE
Make delete use multi-select when more than one pod is launched

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ jira readme
 - [ ] KT-29:  Add rebase command to pull ALL remote items, overwriting local versions
 - [ ] KT-31:  Sort the LISTS, all of them
 - [ ] KT-32:  Add a description/tools field, to house what tools/operation the utility definition is meant to solve
-- [ ] KT-34:  Make the delete command MUTLI_SELECT
 - [ ] KT-45:  Add a "defaultTemplate" setting in the config.yaml, and default to "default", and use that as the template when no --template/-t is provided
 
 ### Done
@@ -137,4 +136,4 @@ jira readme
 - [x] KT-36:  Allow the ability to pass in a set of labels to set for the POD
 - [x] KT-47:  Remove -n from the description of the --name parameter for add utility
 - [x] KT-35:  Add modify alias to the update command
-
+- [x] KT-34:  Make the delete command MUTLI_SELECT

--- a/ask/multi_pod.go
+++ b/ask/multi_pod.go
@@ -1,0 +1,64 @@
+package ask
+
+import (
+	"fmt"
+	"os"
+
+	"ktrouble/common"
+
+	"github.com/AlecAivazis/survey/v2"
+	v1 "k8s.io/api/core/v1"
+)
+
+type (
+	MultiPodAnswer struct {
+		Pod []string `survey:"podname"`
+	}
+)
+
+func PromptForPodList(podList *v1.PodList) []PodDetail {
+
+	podArray := make(map[string]PodDetail, len(podList.Items))
+
+	for _, v := range podList.Items {
+		deleting := "false"
+		if v.DeletionTimestamp != nil {
+			deleting = "true"
+		}
+		podArray[fmt.Sprintf("%s/%s", v.Namespace, v.Name)] = PodDetail{
+			Name:      v.Name,
+			Namespace: v.Namespace,
+			Deleted:   deleting,
+		}
+	}
+
+	podNames := []string{}
+	for _, m := range podArray {
+		if m.Deleted == "false" {
+			podNames = append(podNames, fmt.Sprintf("%s/%s", m.Namespace, m.Name))
+		}
+	}
+
+	var podSurvey = []*survey.Question{
+		{
+			Name: "podname",
+			Prompt: &survey.MultiSelect{
+				Message: "Choose a pod to delete:",
+				Options: podNames,
+			},
+		},
+	}
+
+	opts := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
+
+	podAnswer := &MultiPodAnswer{}
+	if err := survey.Ask(podSurvey, podAnswer, opts); err != nil {
+		common.Logger.WithError(err).Fatal("No pod selected")
+	}
+
+	selectedPods := []PodDetail{}
+	for _, v := range podAnswer.Pod {
+		selectedPods = append(selectedPods, podArray[v])
+	}
+	return selectedPods
+}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -21,10 +21,17 @@ var deleteCmd = &cobra.Command{
 		if c.Client != nil {
 			podList := c.Client.GetCreatedPods()
 
-			if len(podList.Items) > 0 {
+			switch count := len(podList.Items); {
+			case count == 1:
 				selectedPod := ask.PromptForPod(podList)
 
 				c.Client.DeletePod(selectedPod)
+			case count > 1:
+				selectedPods := ask.PromptForPodList(podList)
+
+				for _, p := range selectedPods {
+					c.Client.DeletePod(p)
+				}
 			}
 		} else {
 			common.Logger.Warn("Cannot delete a pod, no valid kubernetes context")


### PR DESCRIPTION
<!--
- Rebase your branch on the latest upstream master
- If this PR contains user facing change, please follow the checklist
- Provide a general summary of your changes in the Title above
-->

## Description

Allow multi-select on deletion of pods

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Dependencies
<!--- If this fix is dependent on code in other repos to be deployed, list that here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [ ] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
- **BREAKING** note on base feature
- Basically whatever formatting we have here, just plain-text
%> command example
- next feature
- note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

- When more than one ktrouble pod is running, use multi-select on the `delete` command

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes

