### PR TITLE
hit a character limit for names, hold to a reasonable amount

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ jira readme
 ### In Flight
 
 - [ ] KT-16:  Start adding godoc comments (In Progress)
-- [ ] KT-62:  Add "requireSecret", "requireConfigmap", and "containerHint" as YAML fields in the utility definitions
 
 ### To Do
 
@@ -113,3 +112,8 @@ jira readme
 - [ ] KT-72:  Add the ability to change the "sleep" list from the CLI
 - [ ] KT-73:  Add --build-cmd switch for launch and attach
 - [ ] KT-74:  Add environment support to support same images in different registries
+
+### Completed
+
+- [x] KT-62:  Add "requireSecret", "requireConfigmap", and "containerHint" as YAML fields in the utility definitions
+- [x] KT-66:  Fix: volume names can only be 63 characters long


### PR DESCRIPTION
## Description

This change was actually applied in the previous commit to main.  

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [x] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
- **BREAKING** note on base feature
- Basically whatever formatting we have here, just plain-text
%> command example
- next feature
- note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

### Changes

### Fixes

- Limit the name of the volume and mount to 53 characters, to allow for some name variation

### Deprecated

### Removed

### Breaking Changes


