### PR TITLE
add a diff command, and enhance the status command

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -7,6 +7,7 @@
 - [add utility](#add-utility)
 - [changelog](#changelog)
 - [delete](#delete)
+- [diff](#diff)
 - [edit](#edit)
 - [edit config](#edit-config)
 - [edit template](#edit-template)
@@ -55,6 +56,7 @@ Available Commands:
   changelog   Get changelog information
   completion  Generate the autocompletion script for the specified shell
   delete      Delete PODs that have been created by ktrouble
+  diff        Get a context diff on each utility definition
   edit        Edit various objects for ktrouble
   fields      Display a list of valid fields to use with the --fields/-f parameter for each command
   genhelp     Output help from all the sub commands
@@ -202,6 +204,32 @@ Usage:
 
 Flags:
   -a, --all   Choose from a list of running PODs from ALL users
+
+Global Flags:
+      --config string      config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings     Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
+      --log-file string    Set the logging level: trace,debug,info,warning,error,fatal
+  -v, --log-level string   Set the logging level: trace,debug,info,warning,error,fatal
+  -n, --namespace string   Specify the namespace to run in, ENV NAMESPACE then -n for preference
+      --no-headers         Suppress header output in Text output
+  -o, --output string      output types: json, text, yaml, gron, raw
+  -s, --show-hidden        Show entries with the 'hidden' property set to 'true'
+  -t, --template string    Specify the template file to use to render the POD manifest (default "default")
+```
+
+[TOC](#TOC)
+
+## diff
+
+```plaintext
+EXAMPLE:
+  The 'diff' command will list the differences between your local 'config.yaml'
+  file 'utilities' definitions and the remote repository.
+
+  > ktrouble diff
+
+Usage:
+  ktrouble diff [flags]
 
 Global Flags:
       --config string      config file (default is $HOME/.splicectl/config.yml)

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"ktrouble/common"
+	"ktrouble/objects"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+// diffCmd represents the status command
+var diffCmd = &cobra.Command{
+	Use:   "diff",
+	Short: "Get a context diff on each utility definition",
+	Long: `EXAMPLE:
+  The 'diff' command will list the differences between your local 'config.yaml'
+  file 'utilities' definitions and the remote repository.
+
+  > ktrouble diff
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		utilityDefinitionDiffs()
+	},
+}
+
+func unmarshallUtilityDefinition(util objects.UtilityPod) string {
+	utilYAML, rerr := yaml.Marshal(util)
+	if rerr != nil {
+		return ""
+	}
+
+	return strings.Replace(string(utilYAML), "\n", "\n    ", -1)
+
+}
+
+func utilityDefinitionDiffs() {
+
+	utilsDifferent := map[string]objects.Status{}
+
+	status := UtilityDefinitionStatus()
+	for _, s := range status {
+		if s.Status != "different" {
+			utilsDifferent[s.Name] = s
+		}
+	}
+
+	_, remoteDefsMap := c.GitUpstream.GetUpstreamDefs()
+
+	utilNames := []string{}
+	for _, l := range c.UtilDefs {
+		utilNames = append(utilNames, l.Name)
+	}
+	sort.Strings(utilNames)
+
+	localDefs := "UtilityDefinitions:\n"
+
+	for _, l := range utilNames {
+		if _, ok := utilsDifferent[l]; !ok {
+			uDef := c.UtilMap[l]
+			yDef := unmarshallUtilityDefinition(uDef)
+			localDefs += "  - " + yDef + "\n"
+		}
+	}
+
+	remoteNames := []string{}
+	for _, r := range remoteDefsMap {
+		remoteNames = append(remoteNames, r.Name)
+	}
+	sort.Strings(remoteNames)
+
+	remoteDefs := "UtilityDefinitions:\n"
+	for _, l := range remoteNames {
+		if _, ok := utilsDifferent[l]; !ok {
+			uDef := remoteDefsMap[l]
+			yDef := unmarshallUtilityDefinition(uDef)
+			remoteDefs += "  - " + yDef + "\n"
+		}
+	}
+	common.Logger.Tracef("local: %s", localDefs)
+	common.Logger.Tracef("\n\n-------------------------------\n\nremote: %s", remoteDefs)
+	common.OutputContextDiff([]byte(localDefs), []byte(remoteDefs), 5)
+}
+
+func init() {
+	RootCmd.AddCommand(diffCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -117,7 +117,7 @@ var RootCmd = &cobra.Command{
 			}
 		}
 
-		if os.Args[1] == "pull" || os.Args[1] == "push" || os.Args[1] == "status" {
+		if os.Args[1] == "pull" || os.Args[1] == "push" || os.Args[1] == "status" || os.Args[1] == "diff" {
 			gitUser := viper.GetString("gitUser")
 			if len(gitUser) == 0 {
 				common.Logger.Fatal("gitUser is not set, use 'ktrouble set config --help'")
@@ -163,6 +163,9 @@ func containsAlias(v string, a []string) bool {
 
 func needKubernetes(arg string, sub string) bool {
 
+	if arg == "diff" {
+		return false
+	}
 	if arg == "get" {
 		switch sub {
 		case "utilities", "sizes", "templates":

--- a/common/diffs.go
+++ b/common/diffs.go
@@ -1,0 +1,104 @@
+package common
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"ktrouble/internal"
+
+	"github.com/pmezard/go-difflib/difflib"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+func OutputContextDiff(local []byte, remote []byte, contextLines int) {
+
+	text := ""
+
+	localReader := bytes.NewReader(local)
+	localBuffer := new(bytes.Buffer)
+	remoteReader := bytes.NewReader(remote)
+	remoteBuffer := new(bytes.Buffer)
+
+	serr := internal.SortYAML(localReader, localBuffer, 2)
+	if serr != nil {
+		Logger.WithError(serr).Error("Error sorting original yaml")
+	}
+	serr = internal.SortYAML(remoteReader, remoteBuffer, 2)
+	if serr != nil {
+		Logger.WithError(serr).Error("Error sorting edit yaml")
+	}
+
+	sortedLocal := localBuffer.Bytes()
+	sortedRemote := remoteBuffer.Bytes()
+
+	switch getDiffStyle() {
+	case "unified":
+		diff := difflib.UnifiedDiff{
+			A:        difflib.SplitLines(string(sortedRemote)),
+			B:        difflib.SplitLines(string(sortedLocal)),
+			FromFile: "Upstream Repository",
+			ToFile:   "Local Repository",
+			Context:  contextLines,
+		}
+		text, _ = difflib.GetUnifiedDiffString(diff)
+	case "context":
+		diff := difflib.ContextDiff{
+			A:        difflib.SplitLines(string(sortedRemote)),
+			B:        difflib.SplitLines(string(sortedLocal)),
+			FromFile: "Upstream Repository",
+			ToFile:   "Local Repository",
+			Context:  contextLines,
+		}
+		text, _ = difflib.GetContextDiffString(diff)
+
+	}
+
+	customPager := getPager()
+	if len(customPager) > 0 {
+		cmd := exec.Command(customPager)
+		// cmd := exec.Command("/usr/local/bin/delta")
+
+		// Feed it with the string you want to display.
+		cmd.Stdin = strings.NewReader(text)
+
+		// This is crucial - otherwise it will write to a null device.
+		cmd.Stdout = os.Stdout
+
+		// Fork off a process and wait for it to terminate.
+		pageerr := cmd.Run()
+		if pageerr != nil {
+			logrus.WithError(pageerr).Error("Error calling to pager")
+		}
+	} else {
+		fmt.Println(text)
+	}
+}
+
+func getPager() string {
+
+	customPager := os.Getenv("KTROUBLE_PAGER")
+	if len(customPager) > 0 {
+		return customPager
+	}
+	customPager = viper.GetString("Pager")
+	if len(customPager) > 0 {
+		return customPager
+	}
+	customPager = os.Getenv("PAGER")
+	if len(customPager) > 0 {
+		return customPager
+	}
+	return ""
+}
+
+func getDiffStyle() string {
+	diffStyle := viper.GetString("diffStyle")
+	if len(diffStyle) > 0 {
+		return diffStyle
+	}
+	return "unified"
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/coreos/go-semver v0.3.0
+	github.com/fatih/color v1.13.0
 	github.com/go-git/go-billy/v5 v5.4.1
 	github.com/go-git/go-git/v5 v5.6.0
 	github.com/maahsome/gron v0.1.0
@@ -12,10 +13,12 @@ require (
 	github.com/muesli/termenv v0.15.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pkg/errors v0.9.1
+	github.com/pmezard/go-difflib v1.0.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.14.0
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.26.2
 	k8s.io/apimachinery v0.26.2
 	k8s.io/client-go v0.26.2
@@ -36,7 +39,6 @@ require (
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
-	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
@@ -106,7 +108,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/cli-runtime v0.26.2 // indirect
 	k8s.io/component-base v0.26.2 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect

--- a/internal/sort.go
+++ b/internal/sort.go
@@ -1,0 +1,120 @@
+package internal
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// CustomLabel is the key used when the yaml to indent doesn't start with an object key
+const CustomLabel string = "YAMLSORT_BEGIN_KEY:"
+
+// ErrNoStartingLabel is an error used when the YAML selection doesn't start with an object
+var ErrNoStartingLabel = errors.New("doesn't start with an object")
+
+// SortYAML sorts a complete or partial YAML file
+func SortYAML(in io.Reader, out io.Writer, indent int) error {
+
+	incomingYAML, err := ioutil.ReadAll(in)
+	if err != nil {
+		return fmt.Errorf("can't read input: %v", err)
+	}
+
+	var hasNoStartingLabel bool
+	rootIndent, err := detectRootIndent(incomingYAML)
+	if err != nil {
+		if !errors.Is(err, ErrNoStartingLabel) {
+			fmt.Fprint(out, string(incomingYAML))
+			return fmt.Errorf("can't detect root indentation: %v", err)
+		}
+
+		hasNoStartingLabel = true
+	}
+
+	if hasNoStartingLabel {
+		incomingYAML = append([]byte(CustomLabel+"\n"), incomingYAML...)
+	}
+
+	var value map[string]interface{}
+	if err := yaml.Unmarshal(incomingYAML, &value); err != nil {
+		fmt.Fprint(out, string(incomingYAML))
+
+		return fmt.Errorf("can't decode YAML: %v", err)
+	}
+
+	var outgoingYAML bytes.Buffer
+	encoder := yaml.NewEncoder(&outgoingYAML)
+	encoder.SetIndent(indent)
+
+	if err := encoder.Encode(&value); err != nil {
+		fmt.Fprint(out, string(incomingYAML))
+		return fmt.Errorf("can't re-encode YAML: %v", err)
+	}
+
+	reindentedYAML, err := indentYAML(outgoingYAML.String(), rootIndent, indent, hasNoStartingLabel)
+	if err != nil {
+		fmt.Fprint(out, string(incomingYAML))
+		return fmt.Errorf("can't re-indent YAML: %v", err)
+	}
+
+	fmt.Fprint(out, reindentedYAML)
+	return nil
+}
+
+func indentYAML(yaml string, rootIndent string, indent int, hasNoStartingLabel bool) (string, error) {
+	var newYAML strings.Builder
+
+	var count int
+	scanner := bufio.NewScanner(strings.NewReader(yaml))
+	for scanner.Scan() {
+		count++
+
+		if count == 1 && hasNoStartingLabel {
+			continue
+		}
+
+		line := scanner.Text()
+		if hasNoStartingLabel {
+			line = line[2:]
+		}
+
+		newYAML.WriteString(rootIndent + line + "\n")
+	}
+
+	if scanner.Err() != nil {
+		return "", fmt.Errorf("can'read line: %v", scanner.Err())
+	}
+
+	return newYAML.String(), nil
+}
+
+func detectRootIndent(yaml []byte) (string, error) {
+	var indent string
+
+	reader := bufio.NewReader(bytes.NewReader(yaml))
+	for {
+		char, _, err := reader.ReadRune()
+		if err != nil {
+			return "", fmt.Errorf("can't read character: %v", err)
+		}
+
+		if char == ' ' || char == '\t' {
+			indent += string(char)
+			continue
+		}
+
+		if char == '-' {
+			return indent, ErrNoStartingLabel
+		}
+
+		break
+	}
+
+	return indent, nil
+}

--- a/internal/sort_test.go
+++ b/internal/sort_test.go
@@ -1,0 +1,106 @@
+package internal_test
+
+import (
+	"bytes"
+	"flag"
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"ktrouble/internal"
+)
+
+var updateFlag = flag.Bool("update-golden", false, "update golden files")
+
+func TestSorting(t *testing.T) {
+	tcs := []struct {
+		Name                   string
+		Indent                 int
+		InputFilePath          string
+		ExpectedOutputFilePath string
+		Err                    string
+	}{
+		{
+			Name:                   "when YAML is a complete object with bigger indentation",
+			Indent:                 4,
+			InputFilePath:          "testdata/object-flat-bigger-indent-input.yaml",
+			ExpectedOutputFilePath: "testdata/object-flat-bigger-indent-output.yaml",
+		},
+		{
+			Name:                   "when YAML is a complete object",
+			Indent:                 2,
+			InputFilePath:          "testdata/object-flat-input.yaml",
+			ExpectedOutputFilePath: "testdata/object-flat-output.yaml",
+		},
+		{
+			Name:                   "when YAML is part of a bigger object (so indented)",
+			Indent:                 2,
+			InputFilePath:          "testdata/object-nested-input.yaml",
+			ExpectedOutputFilePath: "testdata/object-nested-output.yaml",
+		},
+		{
+			Name:                   "when YAML is a list (so invalid YAML)",
+			Indent:                 2,
+			InputFilePath:          "testdata/list-input.yaml",
+			ExpectedOutputFilePath: "testdata/list-output.yaml",
+		},
+		{
+			Name:                   "when YAML is a list (so invalid YAML) and indented",
+			Indent:                 2,
+			InputFilePath:          "testdata/list-nested-input.yaml",
+			ExpectedOutputFilePath: "testdata/list-nested-output.yaml",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.Name, func(t *testing.T) {
+			input, err := os.Open(tc.InputFilePath)
+			if err != nil {
+				t.Fatalf("can't open input '%s': %s", tc.InputFilePath, err)
+			}
+			defer input.Close()
+
+			if updateFlag != nil && *updateFlag {
+				output, err := os.OpenFile(tc.ExpectedOutputFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+				if err != nil {
+					t.Fatalf("can't open golden file '%s' for re-generation: %s", tc.ExpectedOutputFilePath, err)
+				}
+				defer output.Close()
+
+				if err := internal.SortYAML(input, output, tc.Indent); err != nil {
+					t.Fatalf("can't generate golden file: %s", err)
+				}
+				output.Close()
+
+				if _, err := input.Seek(0, io.SeekStart); err != nil {
+					t.Fatalf("can't rewind input file to start after golden file generation: %s", err)
+				}
+			}
+
+			expectedOutputContent, err := ioutil.ReadFile(tc.ExpectedOutputFilePath)
+			if err != nil {
+				t.Fatalf("can't read output '%s': %s", tc.ExpectedOutputFilePath, err)
+			}
+
+			var actualOutput bytes.Buffer
+
+			err = internal.SortYAML(input, &actualOutput, tc.Indent)
+			if err != nil && tc.Err == "" {
+				t.Fatalf("expected no error but got: %s", err)
+			}
+
+			if err == nil && tc.Err != "" {
+				t.Fatalf("expected error '%s' but got none", tc.Err)
+			}
+
+			if tc.Err != "" && tc.Err != err.Error() {
+				t.Fatalf("wrong error. want: %s; got: %s", tc.Err, err)
+			}
+
+			if !bytes.Equal(expectedOutputContent, actualOutput.Bytes()) {
+				t.Fatalf("wrong output. want:\n%s\ngot:\n%s", string(expectedOutputContent), actualOutput.String())
+			}
+		})
+	}
+}

--- a/internal/testdata/list-input.yaml
+++ b/internal/testdata/list-input.yaml
@@ -1,0 +1,6 @@
+- lang: fr
+  value: Bonjour
+- value: Halo
+  lang: de
+- lang: en
+  value: Hello

--- a/internal/testdata/list-nested-input.yaml
+++ b/internal/testdata/list-nested-input.yaml
@@ -1,0 +1,6 @@
+    - lang: fr
+      value: Bonjour
+    - value: Halo
+      lang: de
+    - lang: en
+      value: Hello

--- a/internal/testdata/list-nested-output.yaml
+++ b/internal/testdata/list-nested-output.yaml
@@ -1,0 +1,6 @@
+    - lang: fr
+      value: Bonjour
+    - lang: de
+      value: Halo
+    - lang: en
+      value: Hello

--- a/internal/testdata/list-output.yaml
+++ b/internal/testdata/list-output.yaml
@@ -1,0 +1,6 @@
+- lang: fr
+  value: Bonjour
+- lang: de
+  value: Halo
+- lang: en
+  value: Hello

--- a/internal/testdata/object-flat-bigger-indent-input.yaml
+++ b/internal/testdata/object-flat-bigger-indent-input.yaml
@@ -1,0 +1,8 @@
+greeting:
+  fr: Bonjour
+  de: Halo
+  en: Hello
+farewell:
+  en: Bye
+  fr: Au revoir
+  de: auf Wiedersehen

--- a/internal/testdata/object-flat-bigger-indent-output.yaml
+++ b/internal/testdata/object-flat-bigger-indent-output.yaml
@@ -1,0 +1,8 @@
+farewell:
+    de: auf Wiedersehen
+    en: Bye
+    fr: Au revoir
+greeting:
+    de: Halo
+    en: Hello
+    fr: Bonjour

--- a/internal/testdata/object-flat-input.yaml
+++ b/internal/testdata/object-flat-input.yaml
@@ -1,0 +1,8 @@
+greeting:
+  fr: Bonjour
+  de: Halo
+  en: Hello
+farewell:
+  en: Bye
+  fr: Au revoir
+  de: auf Wiedersehen

--- a/internal/testdata/object-flat-output.yaml
+++ b/internal/testdata/object-flat-output.yaml
@@ -1,0 +1,8 @@
+farewell:
+  de: auf Wiedersehen
+  en: Bye
+  fr: Au revoir
+greeting:
+  de: Halo
+  en: Hello
+  fr: Bonjour

--- a/internal/testdata/object-nested-input.yaml
+++ b/internal/testdata/object-nested-input.yaml
@@ -1,0 +1,8 @@
+          greeting:
+            fr: Bonjour
+            de: Halo
+            en: Hello
+          farewell:
+            en: Bye
+            fr: Au revoir
+            de: auf Wiedersehen

--- a/internal/testdata/object-nested-output.yaml
+++ b/internal/testdata/object-nested-output.yaml
@@ -1,0 +1,8 @@
+          farewell:
+            de: auf Wiedersehen
+            en: Bye
+            fr: Au revoir
+          greeting:
+            de: Halo
+            en: Hello
+            fr: Bonjour


### PR DESCRIPTION
## Description

Make the status compare the entire sorted YAML block
Add a diff command to compare each Utility definition form a sorted YAML block

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [x] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
- **BREAKING** note on base feature
- Basically whatever formatting we have here, just plain-text
%> command example
- next feature
- note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

- Added a `diff` command to output the YAML differences in a utility.

### Changes

- Modified the `status` command to do a compare against a sorted YAML render

### Fixes

### Deprecated

### Removed

### Breaking Changes


