### PR TITLE
attach feature implementation

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -5,6 +5,7 @@
 - [_main_](#ktrouble)
 - [add](#add)
 - [add utility](#add-utility)
+- [attach](#attach)
 - [changelog](#changelog)
 - [delete](#delete)
 - [diff](#diff)
@@ -13,6 +14,7 @@
 - [edit template](#edit-template)
 - [fields](#fields)
 - [get](#get)
+- [get attachments](#get-attachments)
 - [get configs](#get-configs)
 - [get ingresses](#get-ingresses)
 - [get namespace](#get-namespace)
@@ -22,6 +24,7 @@
 - [get serviceaccount](#get-serviceaccount)
 - [get services](#get-services)
 - [get sizes](#get-sizes)
+- [get sleep](#get-sleep)
 - [get templates](#get-templates)
 - [get utilities](#get-utilities)
 - [launch](#launch)
@@ -55,6 +58,7 @@ Usage:
 
 Available Commands:
   add         Add various objects for ktrouble
+  attach      attach a kubernetes troubleshooting container to a running pod
   changelog   Get changelog information
   completion  Generate the autocompletion script for the specified shell
   delete      Delete PODs that have been created by ktrouble
@@ -144,6 +148,49 @@ Flags:
   -r, --repository string    Repository and tag for your utility container, eg: cmaahs/basic-tools:latest
       --require-configmaps   Set the Utilty to always prompt for configmaps
       --require-secrets      Set the Utilty to always prompt for secrets
+
+Global Flags:
+      --config string             config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings            Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
+      --ingress-template string   Specify the ingress template file to use to render the INGRESS manifest, for --create-ingress option (default "default-ingress")
+      --log-file string           Set the logging level: trace,debug,info,warning,error,fatal
+  -v, --log-level string          Set the logging level: trace,debug,info,warning,error,fatal
+  -n, --namespace string          Specify the namespace to run in, ENV NAMESPACE then -n for preference
+      --no-headers                Suppress header output in Text output
+  -o, --output string             output types: json, text, yaml, gron, raw
+      --service-template string   Specify the service template file to use to render the SERVICE manifest, for --create-ingress option (default "default-service")
+  -s, --show-hidden               Show entries with the 'hidden' property set to 'true'
+  -t, --template string           Specify the template file to use to render the POD manifest (default "default")
+```
+
+[TOC](#TOC)
+
+## attach
+
+```plaintext
+EXAMPLE:
+  Just running ktrouble attach will prompt for all the things required to run.
+  Attaching a container to an existing pod is done through the Ephemeral
+  Container feature of Kubernetes.  This feature is only available in
+  Kubernetes 1.16 and later, and must be enabled in the cluster.  The way that
+  Ephemeral Containers work is that a new container is created in the same
+  namespace as the pod, and the new container is attached to the pod's network
+  namespace.  This allows the new container to see the same network as the pod.
+  These Ephemeral Containers are not persisted, and are removed when the primary
+  command that starts the container exits.  From the command line, you launch a
+  new container and after you exit the container, the Ephemeral Container is
+  terminated.  In order to allow us to attach a container and also be able to
+  exec and exit the container without it terminating, we simply run the "sleep"
+  command, and when that sleep duration is over, the container will exit.  There
+  is NO other way to remove an Ephemeral Container definition from a pod.
+
+  > ktrouble attach
+
+Usage:
+  ktrouble attach [flags]
+
+Aliases:
+  attach, att, attachment, a
 
 Global Flags:
       --config string             config file (default is $HOME/.splicectl/config.yml)
@@ -417,6 +464,7 @@ Usage:
   ktrouble get [command]
 
 Available Commands:
+  attachments    Get a list of attached containers
   configs        Get a list of configs
   ingresses      Get a list of ktrouble installed ingresses
   namespace      Get a list of namespaces
@@ -426,6 +474,7 @@ Available Commands:
   serviceaccount Get a list of K8s ServiceAccount(s) in a Namespace
   services       Get a list of ktrouble installed services
   sizes          Get a list of defined sizes
+  sleep          Get a list of sleep times for ephemeral containers
   templates      Get a list of templates
   utilities      Get a list of supported utility container images
 
@@ -443,6 +492,49 @@ Global Flags:
   -t, --template string           Specify the template file to use to render the POD manifest (default "default")
 
 Use "ktrouble get [command] --help" for more information about a command.
+```
+
+[TOC](#TOC)
+
+## get attachments
+
+```plaintext
+EXAMPLE:
+  Get a list of utility containers that are attached to existing PODS that are
+  currently running on the current context kubernetes cluster that were attached
+  with the ktrouble utility.  If the 'enableBashLinks' config.yaml setting is
+  'true', a '<bash: ... >' command will be displayed, otherwise the SHELL path
+  will be displayed.
+
+  > ktrouble get attachments
+
+    NAME                NAMESPACE       STATUS   EXEC
+    basic-tools-e1df2f  common-tooling  Running  <bash:kubectl -n common-tooling exec -it basic-tools-e1df2f -- /bin/bash>
+
+    NAME                NAMESPACE       STATUS   SHELL
+    basic-tools-e1df2f  common-tooling  Running  /bin/bash
+
+Usage:
+  ktrouble get attachments [flags]
+
+Aliases:
+  attachments, attach, att, attachment
+
+Flags:
+  -a, --all   List attached containers for ALL users
+
+Global Flags:
+      --config string             config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings            Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
+      --ingress-template string   Specify the ingress template file to use to render the INGRESS manifest, for --create-ingress option (default "default-ingress")
+      --log-file string           Set the logging level: trace,debug,info,warning,error,fatal
+  -v, --log-level string          Set the logging level: trace,debug,info,warning,error,fatal
+  -n, --namespace string          Specify the namespace to run in, ENV NAMESPACE then -n for preference
+      --no-headers                Suppress header output in Text output
+  -o, --output string             output types: json, text, yaml, gron, raw
+      --service-template string   Specify the service template file to use to render the SERVICE manifest, for --create-ingress option (default "default-service")
+  -s, --show-hidden               Show entries with the 'hidden' property set to 'true'
+  -t, --template string           Specify the template file to use to render the POD manifest (default "default")
 ```
 
 [TOC](#TOC)
@@ -739,6 +831,36 @@ Usage:
 
 Aliases:
   sizes, size, requests, request, limit, limits
+
+Global Flags:
+      --config string             config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings            Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
+      --ingress-template string   Specify the ingress template file to use to render the INGRESS manifest, for --create-ingress option (default "default-ingress")
+      --log-file string           Set the logging level: trace,debug,info,warning,error,fatal
+  -v, --log-level string          Set the logging level: trace,debug,info,warning,error,fatal
+  -n, --namespace string          Specify the namespace to run in, ENV NAMESPACE then -n for preference
+      --no-headers                Suppress header output in Text output
+  -o, --output string             output types: json, text, yaml, gron, raw
+      --service-template string   Specify the service template file to use to render the SERVICE manifest, for --create-ingress option (default "default-service")
+  -s, --show-hidden               Show entries with the 'hidden' property set to 'true'
+  -t, --template string           Specify the template file to use to render the POD manifest (default "default")
+```
+
+[TOC](#TOC)
+
+## get sleep
+
+```plaintext
+EXAMPLE:
+  Display a list of sleep times for ephemeral containers
+
+  > ktrouble get sleep
+
+Usage:
+  ktrouble get sleep [flags]
+
+Aliases:
+  sleep, ephemeral_sleep, uptime
 
 Global Flags:
       --config string             config file (default is $HOME/.splicectl/config.yml)

--- a/ask/ephemeral_mounts.go
+++ b/ask/ephemeral_mounts.go
@@ -1,0 +1,51 @@
+package ask
+
+import (
+	"os"
+	"sort"
+
+	"ktrouble/common"
+
+	"github.com/AlecAivazis/survey/v2"
+	v1 "k8s.io/api/core/v1"
+)
+
+type (
+	EphemeralMountAnswer struct {
+		Mount []string `survey:"mounts"`
+	}
+)
+
+func PromptForEphemeralMounts(mountList []v1.VolumeMount) []v1.VolumeMount {
+
+	var mountArray []string
+	mountMap := make(map[string]v1.VolumeMount)
+	for _, v := range mountList {
+		mountArray = append(mountArray, v.Name)
+		mountMap[v.Name] = v
+	}
+	sort.Strings(mountArray)
+
+	var mountSurvey = []*survey.Question{
+		{
+			Name: "mount",
+			Prompt: &survey.MultiSelect{
+				Message: "Choose the mounts to add to the container:",
+				Options: mountArray,
+			},
+		},
+	}
+
+	opts := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
+
+	mountAnswer := &EphemeralMountAnswer{}
+	if err := survey.Ask(mountSurvey, mountAnswer, opts); err != nil {
+		common.Logger.WithError(err).Fatal("No mounts selected")
+	}
+
+	mounts := []v1.VolumeMount{}
+	for _, v := range mountAnswer.Mount {
+		mounts = append(mounts, mountMap[v])
+	}
+	return mounts
+}

--- a/ask/ephemeral_sleep.go
+++ b/ask/ephemeral_sleep.go
@@ -1,0 +1,46 @@
+package ask
+
+import (
+	"os"
+
+	"ktrouble/common"
+	"ktrouble/objects"
+
+	"github.com/AlecAivazis/survey/v2"
+)
+
+type (
+	EphemeralSleepAnswer struct {
+		EphemeralSleep string `survey:"ephemeralsleep"`
+	}
+)
+
+func PromptForEphemeralSleep(ephemeralSleepDefs []objects.EphemeralSleep) string {
+
+	esArray := []string{}
+	esMap := make(map[string]objects.EphemeralSleep)
+
+	for _, v := range ephemeralSleepDefs {
+		esArray = append(esArray, v.Name)
+		esMap[v.Name] = v
+	}
+
+	var esSurvey = []*survey.Question{
+		{
+			Name: "ephemeralsleep",
+			Prompt: &survey.Select{
+				Message: "Choose a sleep time:",
+				Options: esArray,
+			},
+		},
+	}
+
+	opts := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
+
+	esAnswer := &EphemeralSleepAnswer{}
+	if err := survey.Ask(esSurvey, esAnswer, opts); err != nil {
+		common.Logger.WithError(err).Fatal("No sleep time selected")
+	}
+
+	return esMap[esAnswer.EphemeralSleep].Seconds
+}

--- a/ask/multi_pod.go
+++ b/ask/multi_pod.go
@@ -16,7 +16,7 @@ type (
 	}
 )
 
-func PromptForPodList(podList *v1.PodList) []PodDetail {
+func PromptForPodList(podList *v1.PodList, prompt string) []PodDetail {
 
 	podArray := make(map[string]PodDetail, len(podList.Items))
 

--- a/ask/pod.go
+++ b/ask/pod.go
@@ -21,7 +21,7 @@ type (
 	}
 )
 
-func PromptForPod(podList *v1.PodList) PodDetail {
+func PromptForPod(podList *v1.PodList, prompt string) PodDetail {
 
 	podArray := make(map[string]PodDetail, len(podList.Items))
 
@@ -48,7 +48,7 @@ func PromptForPod(podList *v1.PodList) PodDetail {
 		{
 			Name: "podname",
 			Prompt: &survey.Select{
-				Message: "Choose a pod to delete:",
+				Message: prompt,
 				Options: podNames,
 			},
 		},

--- a/cmd/attach.go
+++ b/cmd/attach.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"ktrouble/defaults"
+
+	"github.com/spf13/cobra"
+)
+
+type attachParam struct {
+	PromptForSecrets    bool
+	PromptForConfigMaps bool
+	PromptForVolumes    bool
+	PromptForMysql      bool
+	PromptForPostgres   bool
+	CreateIngress       bool
+	Port                int
+	Host                string
+	Path                string
+}
+
+var a attachParam
+
+// attachCmd represents the default command
+var attachCmd = &cobra.Command{
+	Use:     "attach",
+	Aliases: defaults.AttachAliases,
+	Short:   "attach a kubernetes troubleshooting container to a running pod",
+	Long: `EXAMPLE:
+  Just running ktrouble attach will prompt for all the things required to run.
+  Attaching a container to an existing pod is done through the Ephemeral
+  Container feature of Kubernetes.  This feature is only available in
+  Kubernetes 1.16 and later, and must be enabled in the cluster.  The way that
+  Ephemeral Containers work is that a new container is created in the same
+  namespace as the pod, and the new container is attached to the pod's network
+  namespace.  This allows the new container to see the same network as the pod.
+  These Ephemeral Containers are not persisted, and are removed when the primary
+  command that starts the container exits.  From the command line, you launch a
+  new container and after you exit the container, the Ephemeral Container is
+  terminated.  In order to allow us to attach a container and also be able to
+  exec and exit the container without it terminating, we simply run the "sleep"
+  command, and when that sleep duration is over, the container will exit.  There
+  is NO other way to remove an Ephemeral Container definition from a pod.
+
+  > ktrouble attach
+
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		utility := ""
+		sa := ""
+		if len(args) > 0 && len(args[0]) > 0 {
+			utility = args[0]
+		}
+		if len(args) > 1 && len(args[1]) > 0 {
+			sa = args[1]
+		}
+
+		standardAttach(utility, sa)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(attachCmd)
+}

--- a/cmd/attach_functions_standard.go
+++ b/cmd/attach_functions_standard.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"ktrouble/ask"
+	"ktrouble/common"
+	"ktrouble/objects"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/muesli/termenv"
+)
+
+func standardAttach(utility string, sa string) {
+
+	termFormatter := termenv.NewOutput(os.Stdout)
+	if c.Client != nil {
+		utilMap := make(map[string]objects.UtilityPod)
+		for _, v := range c.UtilDefs {
+			utilMap[v.Name] = objects.UtilityPod{
+				Name:              v.Name,
+				Repository:        v.Repository,
+				ExecCommand:       v.ExecCommand,
+				RequireSecrets:    v.RequireSecrets,
+				RequireConfigmaps: v.RequireConfigmaps,
+				Hint:              v.Hint,
+			}
+		}
+
+		if utility == "" {
+			utility = ask.PromptForUtility(c.UtilDefs, c.ShowHidden)
+		}
+
+		// Display the HINT
+		if len(utilMap[utility].Hint) > 0 {
+			fmt.Println(utilMap[utility].Hint)
+		}
+
+		utilRepository := utilMap[utility].Repository
+
+		namespace := c.Client.DetermineNamespace(c.Namespace)
+
+		namespacePods := c.Client.GetNamespacePods(namespace)
+		if len(namespacePods.Items) == 0 {
+			common.Logger.Warn("No pods found in namespace")
+			return
+		}
+
+		selectedPod := ask.PromptForPod(namespacePods, "Choose a pod to attach to:")
+		if selectedPod.Name == "" {
+			common.Logger.Warn("No pod selected")
+			return
+		}
+
+		sleepTime := ask.PromptForEphemeralSleep(c.EphemeralSleepDefs)
+		if sleepTime == "" {
+			common.Logger.Warn("No sleep time selected")
+			return
+		}
+
+		// Get a list of mounts in the selected pod
+		mounts := c.Client.GetPodMounts(namespace, selectedPod.Name)
+
+		selectedMounts := []v1.VolumeMount{}
+		if len(mounts) > 0 {
+			selectedMounts = ask.PromptForEphemeralMounts(mounts)
+		}
+		shortUniq := randSeq(c.UniqIdLength)
+		containerName := fmt.Sprintf("%s-%s", utility, shortUniq)
+		aerr := c.Client.AttachContainerToPod(namespace, selectedPod.Name, containerName,
+			utilRepository, sleepTime, selectedMounts)
+		if aerr != nil {
+			common.Logger.WithError(aerr).Fatal("Failed to attach container to pod")
+		}
+
+		if c.EnableBashLinks {
+			hl := fmt.Sprintf("<bash:kubectl -n %s exec -it -c %s %s -- %s>", namespace, containerName, selectedPod.Name, utilMap[utility].ExecCommand)
+			tx := fmt.Sprintf("kubectl -n %s exec -it -c %s %s -- %s", namespace, containerName, selectedPod.Name, utilMap[utility].ExecCommand)
+			fmt.Println(termFormatter.Hyperlink(hl, tx))
+		} else {
+			fmt.Printf("kubectl -n %s exec -it -c %s %s -- %s\n", namespace, containerName, selectedPod.Name, utilMap[utility].ExecCommand)
+		}
+	} else {
+		common.Logger.Warn("Cannot launch a pod, no valid kubernetes context")
+	}
+}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -24,13 +24,13 @@ var deleteCmd = &cobra.Command{
 
 			switch count := len(podList.Items); {
 			case count == 1:
-				selectedPod := ask.PromptForPod(podList)
+				selectedPod := ask.PromptForPod(podList, "Choose a pod to delete:")
 
 				c.Client.DeletePod(selectedPod)
 				c.Client.DeleteAssociatedService(selectedPod)
 				c.Client.DeleteAssociatedIngress(selectedPod)
 			case count > 1:
-				selectedPods := ask.PromptForPodList(podList)
+				selectedPods := ask.PromptForPodList(podList, "Choose a pod to delete:")
 
 				for _, p := range selectedPods {
 					c.Client.DeletePod(p)

--- a/cmd/get/get_attachments.go
+++ b/cmd/get/get_attachments.go
@@ -1,0 +1,75 @@
+package get
+
+import (
+	"ktrouble/common"
+	"ktrouble/defaults"
+	"ktrouble/objects"
+
+	"github.com/spf13/cobra"
+)
+
+type GetAttachmentsParam struct {
+	All bool
+}
+
+var getAttachmentsParam = GetAttachmentsParam{}
+
+// attachmentsCmd represents the running command
+var attachmentsCmd = &cobra.Command{
+	Use:     "attachments",
+	Aliases: defaults.GetAttachmentsAliases,
+	Short:   "Get a list of attached containers",
+	Long: `EXAMPLE:
+  Get a list of utility containers that are attached to existing PODS that are
+  currently running on the current context kubernetes cluster that were attached
+  with the ktrouble utility.  If the 'enableBashLinks' config.yaml setting is
+  'true', a '<bash: ... >' command will be displayed, otherwise the SHELL path
+  will be displayed.
+
+  > ktrouble get attachments
+
+    NAME                NAMESPACE       STATUS   EXEC
+    basic-tools-e1df2f  common-tooling  Running  <bash:kubectl -n common-tooling exec -it basic-tools-e1df2f -- /bin/bash>
+
+    NAME                NAMESPACE       STATUS   SHELL
+    basic-tools-e1df2f  common-tooling  Running  /bin/bash
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		if c.Client != nil {
+			podList := c.Client.GetAttachedContainers(getAttachmentsParam.All)
+
+			podData := objects.PodList{}
+			for _, v := range podList.Items {
+				for _, es := range v.Status.EphemeralContainerStatuses {
+					if es.State.Running != nil {
+						podData = append(podData, objects.Pod{
+							Name:          v.Name,
+							Namespace:     v.Namespace,
+							Status:        "Running",
+							LaunchedBy:    v.Labels["ktrouble.launchedby"],
+							Service:       "",
+							ServicePort:   "",
+							ContainerName: es.Name,
+						})
+					}
+				}
+			}
+
+			c.OutputData(&podData, objects.TextOptions{
+				NoHeaders:    c.NoHeaders,
+				BashLinks:    c.EnableBashLinks,
+				UtilMap:      c.UtilMap,
+				UniqIdLength: c.UniqIdLength,
+			})
+		} else {
+			common.Logger.Warn("Cannot fetch attached containers, no valid kubernetes context")
+		}
+
+	},
+}
+
+func init() {
+	getCmd.AddCommand(attachmentsCmd)
+	attachmentsCmd.Flags().BoolVarP(&getAttachmentsParam.All, "all", "a", false, "List attached containers for ALL users")
+}

--- a/cmd/get/get_ephemeral_sleep.go
+++ b/cmd/get/get_ephemeral_sleep.go
@@ -1,0 +1,29 @@
+package get
+
+import (
+	"ktrouble/defaults"
+	"ktrouble/objects"
+
+	"github.com/spf13/cobra"
+)
+
+// sleepCmd represents the sizes command
+var sleepCmd = &cobra.Command{
+	Use:     "sleep",
+	Aliases: defaults.GetSleepAliases,
+	Short:   "Get a list of sleep times for ephemeral containers",
+	Long: `EXAMPLE:
+  Display a list of sleep times for ephemeral containers
+
+  > ktrouble get sleep
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		c.OutputData(&c.EphemeralSleepDefs, objects.TextOptions{NoHeaders: c.NoHeaders})
+
+	},
+}
+
+func init() {
+	getCmd.AddCommand(sleepCmd)
+}

--- a/cmd/get/get_running.go
+++ b/cmd/get/get_running.go
@@ -44,12 +44,13 @@ var runningCmd = &cobra.Command{
 					servicePort = fmt.Sprintf("%d", service.Items[0].Spec.Ports[0].TargetPort.IntVal)
 				}
 				podData = append(podData, objects.Pod{
-					Name:        v.Name,
-					Namespace:   v.Namespace,
-					Status:      status,
-					LaunchedBy:  v.Labels["launchedby"],
-					Service:     serviceName,
-					ServicePort: servicePort,
+					Name:          v.Name,
+					Namespace:     v.Namespace,
+					Status:        status,
+					LaunchedBy:    v.Labels["launchedby"],
+					Service:       serviceName,
+					ServicePort:   servicePort,
+					ContainerName: "",
 				})
 			}
 

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"ktrouble/defaults"
 	"math/rand"
 
 	"github.com/spf13/cobra"
@@ -23,7 +24,7 @@ var letters = []rune("abcdef0987654321")
 // launchCmd represents the default command
 var launchCmd = &cobra.Command{
 	Use:     "launch",
-	Aliases: []string{"create", "apply", "pod", "l"},
+	Aliases: defaults.LaunchAliases,
 	Short:   launchHelp.Short(),
 	Long:    launchHelp.Long(),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/launch_functions_standard.go
+++ b/cmd/launch_functions_standard.go
@@ -37,7 +37,6 @@ func standardLaunch(utility string, sa string) {
 			fmt.Println(utilMap[utility].Hint)
 		}
 
-		// Detect GAR and prompt for lowers/uppers
 		utilRepository := utilMap[utility].Repository
 
 		namespace := c.Client.DetermineNamespace(c.Namespace)
@@ -120,7 +119,7 @@ func standardLaunch(utility string, sa string) {
 
 		if c.EnableBashLinks {
 			hl := fmt.Sprintf("<bash:kubectl -n %s exec -it %s -- %s>", namespace, fmt.Sprintf("%s-%s", utility, shortUniq), utilMap[utility].ExecCommand)
-			tx := fmt.Sprintf("kubectl -n %s exec -it %s -- %s>", namespace, fmt.Sprintf("%s-%s", utility, shortUniq), utilMap[utility].ExecCommand)
+			tx := fmt.Sprintf("kubectl -n %s exec -it %s -- %s", namespace, fmt.Sprintf("%s-%s", utility, shortUniq), utilMap[utility].ExecCommand)
 			fmt.Println(termFormatter.Hyperlink(hl, tx))
 		} else {
 			fmt.Printf("kubectl -n %s exec -it %s -- %s\n", namespace, fmt.Sprintf("%s-%s", utility, shortUniq), utilMap[utility].ExecCommand)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -334,6 +334,31 @@ func initConfig() {
 		}
 	}
 
+	// Ephemeral Sleep Definitions
+	eserr := viper.UnmarshalKey("ephemeralSleep", &c.EphemeralSleepDefs)
+	if eserr != nil {
+		logrus.Fatal("Error unmarshalling ephemeral sleep...")
+	}
+	if len(c.EphemeralSleepDefs) == 0 {
+		logrus.Warn("Adding default ephemeral sleep to config.yaml")
+		seedEphemeralSleep := defaults.EphemeralSleepList()
+		viper.Set("ephemeralSleep", seedEphemeralSleep)
+		c.EphemeralSleepDefs = defaults.EphemeralSleepList()
+		c.EphemeralSleepMap = make(map[string]objects.EphemeralSleep, len(c.EphemeralSleepDefs))
+		for _, v := range c.EphemeralSleepDefs {
+			c.EphemeralSleepMap[v.Name] = v
+		}
+		verr := viper.WriteConfig()
+		if verr != nil {
+			logrus.WithError(verr).Info("Failed to write config")
+		}
+	} else {
+		c.EphemeralSleepMap = make(map[string]objects.EphemeralSleep, len(c.EphemeralSleepDefs))
+		for _, v := range c.EphemeralSleepDefs {
+			c.EphemeralSleepMap[v.Name] = v
+		}
+	}
+
 	// Node Selector Labels
 	nerr := viper.UnmarshalKey("nodeSelectorLabels", &c.NodeSelectorLabels)
 	if nerr != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -39,6 +39,8 @@ type (
 		TemplateFile        string
 		ServiceTemplateFile string
 		IngressTemplateFile string
+		EphemeralSleepMap   map[string]objects.EphemeralSleep
+		EphemeralSleepDefs  objects.EphemeralSleepList
 	}
 
 	Outputtable interface {

--- a/defaults/constants.go
+++ b/defaults/constants.go
@@ -12,3 +12,7 @@ var GetSizesAliases = []string{"size", "requests", "request", "limit", "limits"}
 var ChangelogAliases = []string{"cl", "changes"}
 var UpdateAliases = []string{"modify"}
 var DeleteAliases = []string{"del"}
+var GetAttachmentsAliases = []string{"attach", "att", "attachment"}
+var AttachAliases = []string{"att", "attachment", "a"}
+var LaunchAliases = []string{"create", "apply", "pod", "l"}
+var GetSleepAliases = []string{"ephemeral_sleep", "uptime"}

--- a/defaults/ephemeral_sleep.go
+++ b/defaults/ephemeral_sleep.go
@@ -1,0 +1,31 @@
+package defaults
+
+import (
+	"ktrouble/objects"
+)
+
+func EphemeralSleepList() []objects.EphemeralSleep {
+
+	return []objects.EphemeralSleep{
+		{
+			Name:    "30 Minutes",
+			Seconds: "1800",
+		},
+		{
+			Name:    "4 Hours",
+			Seconds: "14400",
+		},
+		{
+			Name:    "8 Hours",
+			Seconds: "28800",
+		},
+		{
+			Name:    "12 Hours",
+			Seconds: "43200",
+		},
+		{
+			Name:    "1 Day",
+			Seconds: "86400",
+		},
+	}
+}

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -21,6 +21,7 @@ type KubernetesClient interface {
 	CreatePod(podJSON string, namespace string)
 	CreateService(serviceJSON string, namespace string)
 	CreateIngress(ingressJSON string, namespace string)
+	GetNamespacePods(namespace string) *v1.PodList
 	GetCreatedPods(all bool) *v1.PodList
 	GetNamespaces() *v1.NamespaceList
 	GetNodes() *v1.NodeList
@@ -35,6 +36,9 @@ type KubernetesClient interface {
 	DetermineNamespace(nsParam string) string
 	GetCreatedIngresses(all bool) *networkingv1.IngressList
 	GetCreatedServices(all bool) *v1.ServiceList
+	AttachContainerToPod(namespace string, podName string, containerName string, image string, sleep string, mounts []v1.VolumeMount) error
+	GetAttachedContainers(all bool) *v1.PodList
+	GetPodMounts(namespace string, podName string) []v1.VolumeMount
 }
 
 type kubernetesClient struct {

--- a/kubernetes/pods.go
+++ b/kubernetes/pods.go
@@ -9,12 +9,27 @@ import (
 	"ktrouble/ask"
 	"ktrouble/common"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sYaml "k8s.io/apimachinery/pkg/util/yaml"
 )
 
-func (k *kubernetesClient) GetCreatedPods(all bool) *v1.PodList {
+func (k *kubernetesClient) GetNamespacePods(namespace string) *corev1.PodList {
+	listOptions := metav1.ListOptions{}
+	podList, err := k.Client.CoreV1().Pods(namespace).List(context.TODO(), listOptions)
+
+	if err != nil {
+		common.Logger.WithError(err).Error("could not get list of pods")
+		return &corev1.PodList{}
+	}
+	if len(podList.Items) == 0 {
+		common.Logger.Errorf("no pods in this namespace: %s", namespace)
+		return &corev1.PodList{}
+	}
+	return podList
+}
+
+func (k *kubernetesClient) GetCreatedPods(all bool) *corev1.PodList {
 	labelSelector := fmt.Sprintf("app=ktrouble,launchedby=%s", os.Getenv("USER"))
 	if all {
 		labelSelector = "app=ktrouble"
@@ -26,11 +41,32 @@ func (k *kubernetesClient) GetCreatedPods(all bool) *v1.PodList {
 
 	if err != nil {
 		common.Logger.WithError(err).Error("could not get list of pods")
-		return &v1.PodList{}
+		return &corev1.PodList{}
 	}
 	if len(podList.Items) == 0 {
 		common.Logger.Error("no pods with label app=ktrouble were found on this cluster")
-		return &v1.PodList{}
+		return &corev1.PodList{}
+	}
+	return podList
+}
+
+func (k *kubernetesClient) GetAttachedContainers(all bool) *corev1.PodList {
+	labelSelector := fmt.Sprintf("ktrouble=container,ktrouble.launchedby=%s", os.Getenv("USER"))
+	if all {
+		labelSelector = "ktrouble=container"
+	}
+	listOptions := metav1.ListOptions{
+		LabelSelector: labelSelector,
+	}
+	podList, err := k.Client.CoreV1().Pods("").List(context.TODO(), listOptions)
+
+	if err != nil {
+		common.Logger.WithError(err).Error("could not get list of pods")
+		return &corev1.PodList{}
+	}
+	if len(podList.Items) == 0 {
+		common.Logger.Error("no pods with label ktrouble=container were found on this cluster")
+		return &corev1.PodList{}
 	}
 	return podList
 }
@@ -48,7 +84,7 @@ func (k *kubernetesClient) DeletePod(pod ask.PodDetail) error {
 func (k *kubernetesClient) CreatePod(podJSON string, namespace string) {
 
 	podClient := k.Client.CoreV1().Pods(namespace)
-	newResource := &v1.Pod{}
+	newResource := &corev1.Pod{}
 	if err := k8sYaml.NewYAMLOrJSONDecoder(strings.NewReader(podJSON), 100).Decode(&newResource); err != nil {
 		common.Logger.Errorf("Error converting to K8s: %s", podJSON)
 	}
@@ -57,4 +93,81 @@ func (k *kubernetesClient) CreatePod(podJSON string, namespace string) {
 	if cerr != nil {
 		common.Logger.WithError(cerr).Fatal("Failed to create pod")
 	}
+}
+
+func (k *kubernetesClient) AttachContainerToPod(
+	namespace string,
+	podName string,
+	containerName string,
+	image string,
+	sleep string,
+	mounts []corev1.VolumeMount,
+) error {
+
+	podClient := k.Client.CoreV1().Pods(namespace)
+	pod, err := podClient.Get(context.TODO(), podName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	ephemeralContainer := corev1.EphemeralContainer{
+		EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+			Name:         containerName,
+			Image:        image,
+			Command:      []string{"sleep", sleep},
+			TTY:          false,
+			VolumeMounts: mounts,
+		},
+	}
+
+	// Add the ephemeral container to the pod
+	pod.Spec.EphemeralContainers = append(pod.Spec.EphemeralContainers, ephemeralContainer)
+
+	// Update the pod with the ephemeral container and return the pod so we can update the labels
+	_, err = podClient.UpdateEphemeralContainers(context.TODO(), podName, pod, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+
+	pod, err = podClient.Get(context.TODO(), podName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	// Add a ktrouble label to the pod
+	if pod.Labels == nil {
+		pod.Labels = make(map[string]string)
+		pod.Labels["ktrouble"] = "container"
+		pod.Labels["ktrouble.launchedby"] = os.Getenv("USER")
+	} else {
+		pod.Labels["ktrouble"] = "container"
+		pod.Labels["ktrouble.launchedby"] = os.Getenv("USER")
+	}
+
+	_, err = podClient.Update(context.TODO(), pod, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (k *kubernetesClient) GetPodMounts(namespace string, podName string) []corev1.VolumeMount {
+
+	validMounts := []corev1.VolumeMount{}
+	podClient := k.Client.CoreV1().Pods(namespace)
+	pod, err := podClient.Get(context.TODO(), podName, metav1.GetOptions{})
+	if err != nil {
+		return validMounts
+	}
+
+	// Ephemeral Container do NOT support subPath based mounts
+	for _, c := range pod.Spec.Containers {
+		for _, m := range c.VolumeMounts {
+			if m.SubPath == "" {
+				validMounts = append(validMounts, m)
+			}
+		}
+	}
+	return validMounts
 }

--- a/objects/ephemeral_sleep.go
+++ b/objects/ephemeral_sleep.go
@@ -1,0 +1,102 @@
+package objects
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	"ktrouble/common"
+
+	"github.com/maahsome/gron"
+	"github.com/olekukonko/tablewriter"
+	"gopkg.in/yaml.v2"
+)
+
+type EphemeralSleepList []EphemeralSleep
+
+type EphemeralSleep struct {
+	Name    string `json:"name"`
+	Seconds string `json:"seconds"`
+}
+
+// ToJSON - Write the output as JSON
+func (es *EphemeralSleepList) ToJSON() string {
+	rsJSON, err := json.MarshalIndent(es, "", "  ")
+	if err != nil {
+		common.Logger.WithError(err).Error("Error extracting JSON")
+		return ""
+	}
+	return string(rsJSON[:])
+}
+
+func (es *EphemeralSleepList) ToGRON() string {
+	esJSON, err := json.MarshalIndent(es, "", "  ")
+	if err != nil {
+		common.Logger.WithError(err).Error("Error extracting JSON for GRON")
+	}
+	subReader := strings.NewReader(string(esJSON[:]))
+	subValues := &bytes.Buffer{}
+	ges := gron.NewGron(subReader, subValues)
+	ges.SetMonochrome(false)
+	if serr := ges.ToGron(); serr != nil {
+		common.Logger.WithError(serr).Error("Problem generating GRON syntax")
+		return ""
+	}
+	return string(subValues.Bytes())
+}
+
+func (es *EphemeralSleepList) ToYAML() string {
+	rsYAML, err := yaml.Marshal(es)
+	if err != nil {
+		common.Logger.WithError(err).Error("Error extracting YAML")
+		return ""
+	}
+	return string(rsYAML[:])
+}
+
+func (es *EphemeralSleepList) ToTEXT(to TextOptions) string {
+
+	noHeaders := to.NoHeaders
+
+	buf, row := new(bytes.Buffer), make([]string, 0)
+
+	// ************************** TableWriter ******************************
+	table := tablewriter.NewWriter(buf)
+	if !noHeaders {
+		headerText := []string{"NAME", "SECONDS"}
+		table.SetHeader(headerText)
+		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	}
+
+	table.SetAutoWrapText(false)
+	table.SetAutoFormatHeaders(false)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetTablePadding("\t") // pad with tabs
+	table.SetNoWhiteSpace(true)
+
+	mapList := make(map[string]EphemeralSleep, len(*es))
+	nameList := []string{}
+
+	for _, v := range *es {
+		mapList[v.Name] = v
+		nameList = append(nameList, v.Name)
+	}
+
+	for _, v := range nameList {
+		row = []string{
+			mapList[v].Name,
+			mapList[v].Seconds,
+		}
+		table.Append(row)
+	}
+
+	table.Render()
+
+	return buf.String()
+
+}


### PR DESCRIPTION
## Description

I recently discovered the kubectl debug command, which allows one to add an ephemeral container to an existing pod.  While there are some limitations, I figured it would be good to leverage our list of utility images and be able to run them as ephemeral containers.  The way ephemeral containers are meant to work, is to launch using the debug command like this kubectl debug -it --image=nicolaka/netshoot svc-workflow-645cfcb994-4bwpq -n platform-services -- /bin/bash and when you are done, you exit the bash shell and the ephemeral container terminates.  So, just like I do with the individual launched utility PODs, which is to launch with the base command of sleep N, which keeps the container running for N amount of time, which allows one to use the kubectl exec command to get into the container.  We are doing the same thing here.  The reality is that there is NO way to remove an ephemeral container from a POD once launched.  It simply runs to completion and then stays associated with the POD as a terminated container.  With the utility POD launches, I simply us a day of seconds to keep the POD running, figuring that you are likely to use ktrouble delete to terminate the POD long before the day runs out.  With no way to detach an ephemeral container, I've decided to prompt for a lifespan of the container, allowing the person attaching the container to control how long it will run before it terminates.

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [x] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
- **BREAKING** note on base feature
- Basically whatever formatting we have here, just plain-text
%> command example
- next feature
- note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

- Add the `attach` command, allowing one to add an ephemeral container to an existing POD
- Add the `get attachments` command, allowing one to list the currently active attached ephemeral containers
- Add the `get sleep` command to list the sleep values from the config file
- The config now contains a list of "sleep time" options that will be presented to the user for setting the run length of the attached container

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes


