### PR TITLE
add environment support, and a bunch of other improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ cmd/changelog/*
 
 # Need to disregard this, as it is an artifact produced by pipeline
 vRELEASE.md
+
+# some local stuff
+TODO.md
+.vscode/*
+

--- a/HELP.md
+++ b/HELP.md
@@ -4,6 +4,7 @@
 
 - [_main_](#ktrouble)
 - [add](#add)
+- [add environment](#add-environment)
 - [add utility](#add-utility)
 - [attach](#attach)
 - [changelog](#changelog)
@@ -16,6 +17,7 @@
 - [get](#get)
 - [get attachments](#get-attachments)
 - [get configs](#get-configs)
+- [get environments](#get-environments)
 - [get ingresses](#get-ingresses)
 - [get namespace](#get-namespace)
 - [get node](#get-node)
@@ -28,14 +30,17 @@
 - [get templates](#get-templates)
 - [get utilities](#get-utilities)
 - [launch](#launch)
+- [migrate](#migrate)
 - [pull](#pull)
 - [push](#push)
 - [remove](#remove)
+- [remove environment](#remove-environment)
 - [remove utility](#remove-utility)
 - [set](#set)
 - [set config](#set-config)
 - [status](#status)
 - [update](#update)
+- [update environment](#update-environment)
 - [update utility](#update-utility)
 - [version](#version)
 
@@ -69,6 +74,7 @@ Available Commands:
   get         Get various internal configuration and kubernetes resource listings
   help        Help about any command
   launch      Launch a kubernetes troubleshooting pod
+  migrate     Migrate a repostiory to the current version
   pull        Pull utility definitions from git
   push        Push local objects to upstream git repository
   remove      Remove various objects for ktrouble
@@ -107,7 +113,11 @@ Usage:
   ktrouble add [flags]
   ktrouble add [command]
 
+Aliases:
+  add, mk
+
 Available Commands:
+  environment Add an environment definition to the ktrouble configuration
   utility     Add a utility definition to the ktrouble configuration
 
 Global Flags:
@@ -128,6 +138,42 @@ Use "ktrouble add [command] --help" for more information about a command.
 
 [TOC](#TOC)
 
+## add environment
+
+```plaintext
+EXAMPLE:
+  Use 'add environment' command to add a new environment definition to your 'config.yaml'
+  file
+
+    > ktrouble add environment -e 'lowers' -r 'us-docker.pkg.dev/my-lower-repo'
+
+Usage:
+  ktrouble add environment [flags]
+
+Aliases:
+  environment, env, environments
+
+Flags:
+  -x, --exclude             Exclude from 'push' to central repository
+  -e, --name string         Unique name for your environment definition
+  -r, --repository string   Repository for your environment, eg: us-docker.pkg.dev/my-lower-repo
+
+Global Flags:
+      --config string             config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings            Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
+      --ingress-template string   Specify the ingress template file to use to render the INGRESS manifest, for --create-ingress option (default "default-ingress")
+      --log-file string           Set the logging level: trace,debug,info,warning,error,fatal
+  -v, --log-level string          Set the logging level: trace,debug,info,warning,error,fatal
+  -n, --namespace string          Specify the namespace to run in, ENV NAMESPACE then -n for preference
+      --no-headers                Suppress header output in Text output
+  -o, --output string             output types: json, text, yaml, gron, raw
+      --service-template string   Specify the service template file to use to render the SERVICE manifest, for --create-ingress option (default "default-service")
+  -s, --show-hidden               Show entries with the 'hidden' property set to 'true'
+  -t, --template string           Specify the template file to use to render the POD manifest (default "default")
+```
+
+[TOC](#TOC)
+
 ## add utility
 
 ```plaintext
@@ -140,14 +186,19 @@ EXAMPLE:
 Usage:
   ktrouble add utility [flags]
 
+Aliases:
+  utility, utility, utils, util, container, containers, image, images
+
 Flags:
-  -c, --cmd string           Default shell/command to use when 'exec'ing into the POD (default "/bin/sh")
-  -e, --exclude              Exclude from 'push' to central repository
-      --hint-file string     Specify a file containing the hint text
-  -u, --name string          Unique name for your utility pod
-  -r, --repository string    Repository and tag for your utility container, eg: cmaahs/basic-tools:latest
-      --require-configmaps   Set the Utilty to always prompt for configmaps
-      --require-secrets      Set the Utilty to always prompt for secrets
+  -c, --cmd string             Default shell/command to use when 'exec'ing into the POD (default "/bin/sh")
+  -e, --environments strings   Specify an array of environment names: eg, --environments 'lowers,uppers'
+  -x, --exclude                Exclude from 'push' to central repository
+      --hint-file string       Specify a file containing the hint text
+  -u, --name string            Unique name for your utility pod
+  -r, --repository string      Repository and tag for your utility container, eg: cmaahs/basic-tools:latest
+      --require-configmaps     Set the Utilty to always prompt for configmaps
+      --require-secrets        Set the Utilty to always prompt for secrets
+      --toggle-hidden          Switch the current 'hidden' flag for the utility definition
 
 Global Flags:
       --config string             config file (default is $HOME/.splicectl/config.yml)
@@ -289,6 +340,9 @@ EXAMPLE:
 
 Usage:
   ktrouble diff [flags]
+
+Flags:
+      --env   Use this switch to operate on the environment definitions
 
 Global Flags:
       --config string             config file (default is $HOME/.splicectl/config.yml)
@@ -466,6 +520,7 @@ Usage:
 Available Commands:
   attachments    Get a list of attached containers
   configs        Get a list of configs
+  environments   Get a list of defined environments
   ingresses      Get a list of ktrouble installed ingresses
   namespace      Get a list of namespaces
   node           Get a list of node labels
@@ -562,6 +617,36 @@ Usage:
 
 Aliases:
   configs, size, requests, request, limit, limits
+
+Global Flags:
+      --config string             config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings            Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
+      --ingress-template string   Specify the ingress template file to use to render the INGRESS manifest, for --create-ingress option (default "default-ingress")
+      --log-file string           Set the logging level: trace,debug,info,warning,error,fatal
+  -v, --log-level string          Set the logging level: trace,debug,info,warning,error,fatal
+  -n, --namespace string          Specify the namespace to run in, ENV NAMESPACE then -n for preference
+      --no-headers                Suppress header output in Text output
+  -o, --output string             output types: json, text, yaml, gron, raw
+      --service-template string   Specify the service template file to use to render the SERVICE manifest, for --create-ingress option (default "default-service")
+  -s, --show-hidden               Show entries with the 'hidden' property set to 'true'
+  -t, --template string           Specify the template file to use to render the POD manifest (default "default")
+```
+
+[TOC](#TOC)
+
+## get environments
+
+```plaintext
+EXAMPLE:
+  Display a list of environments defined in the configuration file
+
+    > ktrouble get environments
+
+Usage:
+  ktrouble get environments [flags]
+
+Aliases:
+  environments, env, environments
 
 Global Flags:
       --config string             config file (default is $HOME/.splicectl/config.yml)
@@ -1002,6 +1087,36 @@ Global Flags:
 
 [TOC](#TOC)
 
+## migrate
+
+```plaintext
+EXAMPLE:
+  ktrouble uses a versioned directory structure to store the data.  This command
+  will create a new version directory in the repository.  The existing data will
+  remain in the old version directory.  The new version directory will be
+  initialized with the current version data.
+
+    > ktrouble migrate
+
+Usage:
+  ktrouble migrate [flags]
+
+Global Flags:
+      --config string             config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings            Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
+      --ingress-template string   Specify the ingress template file to use to render the INGRESS manifest, for --create-ingress option (default "default-ingress")
+      --log-file string           Set the logging level: trace,debug,info,warning,error,fatal
+  -v, --log-level string          Set the logging level: trace,debug,info,warning,error,fatal
+  -n, --namespace string          Specify the namespace to run in, ENV NAMESPACE then -n for preference
+      --no-headers                Suppress header output in Text output
+  -o, --output string             output types: json, text, yaml, gron, raw
+      --service-template string   Specify the service template file to use to render the SERVICE manifest, for --create-ingress option (default "default-service")
+  -s, --show-hidden               Show entries with the 'hidden' property set to 'true'
+  -t, --template string           Specify the template file to use to render the POD manifest (default "default")
+```
+
+[TOC](#TOC)
+
 ## pull
 
 ```plaintext
@@ -1022,6 +1137,7 @@ Usage:
 
 Flags:
   -a, --all   Specify --all to list locally modified definitions as pull selections
+      --env   Use this switch to operate on the environment definitions
 
 Global Flags:
       --config string             config file (default is $HOME/.splicectl/config.yml)
@@ -1053,6 +1169,9 @@ EXAMPLE:
 Usage:
   ktrouble push [flags]
 
+Flags:
+      --env   Use this switch to operate on the environment definitions
+
 Global Flags:
       --config string             config file (default is $HOME/.splicectl/config.yml)
   -f, --fields strings            Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
@@ -1079,7 +1198,11 @@ Usage:
   ktrouble remove [flags]
   ktrouble remove [command]
 
+Aliases:
+  remove, rm
+
 Available Commands:
+  environment Remove an environment from the config file, or HIDE it if it is an upstream definition, use --remove-upstream to remove it from the upstream repository
   utility     Remove a utility from the config file, or HIDE it if it is an upstream definition
 
 Global Flags:
@@ -1100,6 +1223,41 @@ Use "ktrouble remove [command] --help" for more information about a command.
 
 [TOC](#TOC)
 
+## remove environment
+
+```plaintext
+EXAMPLE:
+  The 'remove environment' command will prompt to select an environment definition to
+  remove from your local 'config.yaml' file
+
+    > ktrouble remove environment
+
+Usage:
+  ktrouble remove environment [flags]
+
+Aliases:
+  environment, env, environments
+
+Flags:
+  -e, --name string       Unique name of your environment
+  -r, --remove-upstream   Remove the environment from the upstream repository on next push
+
+Global Flags:
+      --config string             config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings            Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
+      --ingress-template string   Specify the ingress template file to use to render the INGRESS manifest, for --create-ingress option (default "default-ingress")
+      --log-file string           Set the logging level: trace,debug,info,warning,error,fatal
+  -v, --log-level string          Set the logging level: trace,debug,info,warning,error,fatal
+  -n, --namespace string          Specify the namespace to run in, ENV NAMESPACE then -n for preference
+      --no-headers                Suppress header output in Text output
+  -o, --output string             output types: json, text, yaml, gron, raw
+      --service-template string   Specify the service template file to use to render the SERVICE manifest, for --create-ingress option (default "default-service")
+  -s, --show-hidden               Show entries with the 'hidden' property set to 'true'
+  -t, --template string           Specify the template file to use to render the POD manifest (default "default")
+```
+
+[TOC](#TOC)
+
 ## remove utility
 
 ```plaintext
@@ -1112,8 +1270,12 @@ EXAMPLE:
 Usage:
   ktrouble remove utility [flags]
 
+Aliases:
+  utility, utility, utils, util, container, containers, image, images
+
 Flags:
-  -u, --name string   Unique name for your utility pod
+  -u, --name string       Unique name of your utility pod
+  -r, --remove-upstream   Remove the utility pod from the upstream repository on next push
 
 Global Flags:
       --config string             config file (default is $HOME/.splicectl/config.yml)
@@ -1244,6 +1406,9 @@ EXAMPLE:
 Usage:
   ktrouble status [flags]
 
+Flags:
+      --env   Use this switch to operate on the environment definitions
+
 Global Flags:
       --config string             config file (default is $HOME/.splicectl/config.yml)
   -f, --fields strings            Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
@@ -1275,6 +1440,7 @@ Aliases:
   update, modify
 
 Available Commands:
+  environment Update an existing environment definition in the local config.yaml file
   utility     Update an existing utility pod definition in the local config.yaml file
 
 Global Flags:
@@ -1291,6 +1457,47 @@ Global Flags:
   -t, --template string           Specify the template file to use to render the POD manifest (default "default")
 
 Use "ktrouble update [command] --help" for more information about a command.
+```
+
+[TOC](#TOC)
+
+## update environment
+
+```plaintext
+EXAMPLE:
+  Toggle the 'exclude from push' flag for an environment definition.
+
+    > ktrouble update environment -e lowers --toggle-exclude
+
+EXAMPLE:
+  Change the 'repository' for the definition 'lowers' to '8675309.dkr.ecr.us-west-2.amazonaws.com'
+
+    > ktrouble update environment -e lower -r '8675309.dkr.ecr.us-west-2.amazonaws.com'
+
+Usage:
+  ktrouble update environment [flags]
+
+Aliases:
+  environment, env, environments
+
+Flags:
+  -e, --name string         Unique name for your environment, eg: uppers or lowers
+  -r, --repository string   Repository for your environment, eg: us-docker.pkg.dev/my-lower-repo
+  -x, --toggle-exclude      Switch the current 'excludeFromShare' flag for the environment definition
+      --toggle-hidden       Switch the current 'Hidden' flag for the environment definition
+
+Global Flags:
+      --config string             config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings            Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
+      --ingress-template string   Specify the ingress template file to use to render the INGRESS manifest, for --create-ingress option (default "default-ingress")
+      --log-file string           Set the logging level: trace,debug,info,warning,error,fatal
+  -v, --log-level string          Set the logging level: trace,debug,info,warning,error,fatal
+  -n, --namespace string          Specify the namespace to run in, ENV NAMESPACE then -n for preference
+      --no-headers                Suppress header output in Text output
+  -o, --output string             output types: json, text, yaml, gron, raw
+      --service-template string   Specify the service template file to use to render the SERVICE manifest, for --create-ingress option (default "default-service")
+  -s, --show-hidden               Show entries with the 'hidden' property set to 'true'
+  -t, --template string           Specify the template file to use to render the POD manifest (default "default")
 ```
 
 [TOC](#TOC)
@@ -1316,12 +1523,19 @@ EXAMPLE:
 Usage:
   ktrouble update utility [flags]
 
+Aliases:
+  utility, utility, utils, util, container, containers, image, images
+
 Flags:
-  -c, --cmd string          Default shell/command to use when 'exec'ing into the POD
-  -u, --name string         Unique name for your utility pod
-  -r, --repository string   Repository and tag for your utility container, eg: cmaahs/basic-tools:latest
-  -e, --toggle-exclude      Switch the current 'excludeFromShare' flag for the utility definition
-      --toggle-hidden       Switch the current 'hidden' flag for the utility definition
+  -c, --cmd string             Default shell/command to use when 'exec'ing into the POD
+  -e, --environments strings   Specify an array of environment names: eg, --environments 'lowers,uppers'
+      --hint-file string       Specify a file containing the hint text
+  -u, --name string            Unique name for your utility pod
+  -r, --repository string      Repository and tag for your utility container, eg: cmaahs/basic-tools:latest
+      --require-configmaps     Set the Utilty to always prompt for configmaps
+      --require-secrets        Set the Utilty to always prompt for secrets
+  -x, --toggle-exclude         Switch the current 'excludeFromShare' flag for the utility definition
+      --toggle-hidden          Switch the current 'hidden' flag for the utility definition
 
 Global Flags:
       --config string             config file (default is $HOME/.splicectl/config.yml)

--- a/ask/utility.go
+++ b/ask/utility.go
@@ -1,6 +1,7 @@
 package ask
 
 import (
+	"fmt"
 	"os"
 	"sort"
 
@@ -16,12 +17,20 @@ type (
 	}
 )
 
-func PromptForUtility(utils []objects.UtilityPod, showHidden bool) string {
+func PromptForUtility(utils []objects.UtilityPod, envMap map[string]objects.Environment, showHidden bool) string {
 
 	var utilArray []string
 	for _, v := range utils {
 		if !v.Hidden || showHidden {
-			utilArray = append(utilArray, v.Name)
+			if v.Environments == nil {
+				utilArray = append(utilArray, v.Name)
+			} else {
+				for _, env := range v.Environments {
+					if !envMap[env].Hidden || showHidden {
+						utilArray = append(utilArray, fmt.Sprintf("%s/%s", env, v.Name))
+					}
+				}
+			}
 		}
 	}
 	sort.Strings(utilArray)

--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -2,20 +2,23 @@ package add
 
 import (
 	"ktrouble/config"
+	"ktrouble/defaults"
 	help "ktrouble/help/add"
 
 	"github.com/spf13/cobra"
 )
 
 var addHelp = help.AddCmd{}
+var addEnvironmentHelp = help.AddEnvironmentCmd{}
 var addUtilityHelp = help.AddUtilityCmd{}
 
 var addCmd = &cobra.Command{
-	Use:   "add",
-	Args:  cobra.MinimumNArgs(1),
-	Short: addHelp.Short(),
-	Long:  addHelp.Long(),
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "add",
+	Aliases: defaults.AddAliases,
+	Args:    cobra.MinimumNArgs(1),
+	Short:   addHelp.Short(),
+	Long:    addHelp.Long(),
+	Run:     func(cmd *cobra.Command, args []string) {},
 }
 
 var c *config.Config

--- a/cmd/add/add_environment.go
+++ b/cmd/add/add_environment.go
@@ -1,0 +1,110 @@
+package add
+
+import (
+	"ktrouble/common"
+	"ktrouble/defaults"
+	"ktrouble/objects"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// environmentParam is used to store command line parameters
+var environmentParam objects.Environment
+
+// environmentCmd represents the utility command
+var environmentCmd = &cobra.Command{
+	Use:     "environment",
+	Aliases: defaults.EnvironmentAliases,
+	Short:   addEnvironmentHelp.Short(),
+	Long:    addEnvironmentHelp.Long(),
+	Run: func(cmd *cobra.Command, args []string) {
+		if checkAddEnvironmentParams() {
+			u, err := addEnvironment()
+			if err != nil {
+				common.Logger.WithError(err).Error("Failed to add the environment definition")
+			}
+			if !c.FormatOverridden {
+				c.OutputFormat = "text"
+			}
+			added := objects.EnvironmentList{}
+			added = append(added, u)
+			c.OutputData(&added, objects.TextOptions{
+				NoHeaders: c.NoHeaders,
+				Fields:    c.Fields,
+			})
+		} else {
+			common.Logger.Error("Parameters passed in have failed checks.  Please review the warnings above")
+		}
+	},
+}
+
+func checkAddEnvironmentParams() bool {
+
+	allParamsSet := true
+	if len(environmentParam.Name) == 0 {
+		allParamsSet = false
+		common.Logger.Warn("The --name/-e parameter must be set")
+	}
+	if len(environmentParam.Repository) == 0 {
+		allParamsSet = false
+		common.Logger.Warn("The --repository/-r repository parameter must be set")
+	}
+	if allParamsSet {
+		for _, v := range c.EnvDefs {
+			showUtil := false
+			u := objects.EnvironmentList{}
+			common.Logger.Debugf("environmentParam.Name: %s, exising: %s", utilityParam.Name, v.Name)
+			if environmentParam.Name == v.Name {
+				allParamsSet = false
+				showUtil = true
+				u = append(u, v)
+				common.Logger.Warn("The --name/-e environment name clashes with an existing environment name, please choose another, or use 'update environment' to update the existing environment")
+			}
+			if environmentParam.Repository == v.Repository {
+				allParamsSet = false
+				showUtil = true
+				u = append(u, v)
+				common.Logger.Warnf("The --repository/-r parameter clashes with an existing environment: %s, please consider using that utility definition", v.Name)
+			}
+			if showUtil {
+				if !c.FormatOverridden {
+					c.OutputFormat = "text"
+				}
+				c.OutputData(&u, objects.TextOptions{
+					NoHeaders:  c.NoHeaders,
+					ShowHidden: c.ShowHidden,
+					Fields:     c.Fields,
+				})
+			}
+		}
+	}
+	return allParamsSet
+}
+
+func addEnvironment() (objects.Environment, error) {
+
+	newEnv := objects.Environment{
+		Name:             environmentParam.Name,
+		Repository:       environmentParam.Repository,
+		Source:           "local",
+		ExcludeFromShare: environmentParam.ExcludeFromShare,
+	}
+
+	c.EnvDefs = append(c.EnvDefs, newEnv)
+	viper.Set("environments", c.EnvDefs)
+	verr := viper.WriteConfig()
+	if verr != nil {
+		common.Logger.WithError(verr).Info("Failed to write config")
+		return newEnv, verr
+	}
+	return newEnv, nil
+}
+
+func init() {
+	addCmd.AddCommand(environmentCmd)
+
+	environmentCmd.Flags().StringVarP(&environmentParam.Name, "name", "e", "", "Unique name for your environment definition")
+	environmentCmd.Flags().StringVarP(&environmentParam.Repository, "repository", "r", "", "Repository for your environment, eg: us-docker.pkg.dev/my-lower-repo")
+	environmentCmd.Flags().BoolVarP(&environmentParam.ExcludeFromShare, "exclude", "x", false, "Exclude from 'push' to central repository")
+}

--- a/cmd/add/add_utility.go
+++ b/cmd/add/add_utility.go
@@ -1,8 +1,8 @@
 package add
 
 import (
-	"fmt"
 	"ktrouble/common"
+	"ktrouble/defaults"
 	"ktrouble/objects"
 	"os"
 
@@ -15,9 +15,10 @@ var utilityParam objects.UtilityPod
 
 // utilityCmd represents the utility command
 var utilityCmd = &cobra.Command{
-	Use:   "utility",
-	Short: addUtilityHelp.Short(),
-	Long:  addUtilityHelp.Long(),
+	Use:     "utility",
+	Aliases: defaults.GetUtilitesAliases,
+	Short:   addUtilityHelp.Short(),
+	Long:    addUtilityHelp.Long(),
 	Run: func(cmd *cobra.Command, args []string) {
 		if checkAddUtilityParams() {
 			u, err := addUtility()
@@ -58,6 +59,14 @@ func checkAddUtilityParams() bool {
 			common.Logger.Warn("The file pointed to by the --hint-file must exist")
 		}
 	}
+	if len(utilityParam.Environments) > 0 {
+		common.Logger.Tracef("Environments: %s", utilityParam.Environments)
+		if !objects.EnvironmentsExist(c.EnvMap, utilityParam.Environments) {
+			allParamsSet = false
+			common.Logger.Warnf("The --environments parameter must be set to valid environment names, %s", utilityParam.Environments)
+			common.Logger.Warn("Please use 'get environments' to see the list of valid environment names")
+		}
+	}
 	if allParamsSet {
 		for _, v := range c.UtilDefs {
 			showUtil := false
@@ -92,11 +101,6 @@ func checkAddUtilityParams() bool {
 
 func addUtility() (objects.UtilityPod, error) {
 
-	appSemVer, perr := common.ParseSemver(c.VersionDetail.SemVer)
-	if perr != nil {
-		return objects.UtilityPod{}, perr
-	}
-
 	newUtil := objects.UtilityPod{
 		Name:              utilityParam.Name,
 		Repository:        utilityParam.Repository,
@@ -105,7 +109,8 @@ func addUtility() (objects.UtilityPod, error) {
 		ExcludeFromShare:  utilityParam.ExcludeFromShare,
 		RequireSecrets:    utilityParam.RequireSecrets,
 		RequireConfigmaps: utilityParam.RequireConfigmaps,
-		Version:           fmt.Sprintf("v%d", appSemVer.Major),
+		RemoveUpstream:    false,
+		Environments:      utilityParam.Environments,
 	}
 
 	hintData := []byte{}
@@ -138,10 +143,12 @@ func init() {
 	utilityCmd.Flags().StringVarP(&utilityParam.Name, "name", "u", "", "Unique name for your utility pod")
 	utilityCmd.Flags().StringVarP(&utilityParam.Repository, "repository", "r", "", "Repository and tag for your utility container, eg: cmaahs/basic-tools:latest")
 	utilityCmd.Flags().StringVarP(&utilityParam.ExecCommand, "cmd", "c", "/bin/sh", "Default shell/command to use when 'exec'ing into the POD")
-	utilityCmd.Flags().BoolVarP(&utilityParam.ExcludeFromShare, "exclude", "e", false, "Exclude from 'push' to central repository")
+	utilityCmd.Flags().BoolVarP(&utilityParam.ExcludeFromShare, "exclude", "x", false, "Exclude from 'push' to central repository")
+	utilityCmd.Flags().BoolVar(&utilityParam.Hidden, "toggle-hidden", false, "Switch the current 'hidden' flag for the utility definition")
 	utilityCmd.Flags().BoolVar(&utilityParam.RequireSecrets, "require-secrets", false, "Set the Utilty to always prompt for secrets")
 	utilityCmd.Flags().BoolVar(&utilityParam.RequireConfigmaps, "require-configmaps", false, "Set the Utilty to always prompt for configmaps")
 	utilityCmd.Flags().StringVar(&utilityParam.Hint, "hint-file", "", "Specify a file containing the hint text")
+	utilityCmd.Flags().StringSliceVarP(&utilityParam.Environments, "environments", "e", []string{}, "Specify an array of environment names: eg, --environments 'lowers,uppers'")
 }
 
 // fileExists checks if file exists

--- a/cmd/attach_functions_standard.go
+++ b/cmd/attach_functions_standard.go
@@ -17,28 +17,16 @@ func standardAttach(utility string, sa string) {
 
 	termFormatter := termenv.NewOutput(os.Stdout)
 	if c.Client != nil {
-		utilMap := make(map[string]objects.UtilityPod)
-		for _, v := range c.UtilDefs {
-			utilMap[v.Name] = objects.UtilityPod{
-				Name:              v.Name,
-				Repository:        v.Repository,
-				ExecCommand:       v.ExecCommand,
-				RequireSecrets:    v.RequireSecrets,
-				RequireConfigmaps: v.RequireConfigmaps,
-				Hint:              v.Hint,
-			}
-		}
+		utilMap := objects.GetUtilityMap(c.UtilDefs, c.EnvMap)
 
 		if utility == "" {
-			utility = ask.PromptForUtility(c.UtilDefs, c.ShowHidden)
+			utility = ask.PromptForUtility(c.UtilDefs, c.EnvMap, c.ShowHidden)
 		}
 
 		// Display the HINT
 		if len(utilMap[utility].Hint) > 0 {
 			fmt.Println(utilMap[utility].Hint)
 		}
-
-		utilRepository := utilMap[utility].Repository
 
 		namespace := c.Client.DetermineNamespace(c.Namespace)
 
@@ -70,7 +58,7 @@ func standardAttach(utility string, sa string) {
 		shortUniq := randSeq(c.UniqIdLength)
 		containerName := fmt.Sprintf("%s-%s", utility, shortUniq)
 		aerr := c.Client.AttachContainerToPod(namespace, selectedPod.Name, containerName,
-			utilRepository, sleepTime, selectedMounts)
+			utilMap[utility].Repository, sleepTime, selectedMounts)
 		if aerr != nil {
 			common.Logger.WithError(aerr).Fatal("Failed to attach container to pod")
 		}

--- a/cmd/fields.go
+++ b/cmd/fields.go
@@ -22,7 +22,8 @@ func displayFieldHelp() {
 
   COMMAND: get|add|update|remove utility
 
-      FIELDS: NAME, REPOSITORY, EXEC, HIDDEN, EXCLUDED, SOURCE
+      FIELDS: NAME, REPOSITORY, EXEC, HIDDEN, EXCLUDED, SOURCE, ENVIRONMENTS,
+              REQUIRECONFIGMAPS, REQUIRESECRETS, HINT, REMOVE_UPSTREAM
 `
 
 	fmt.Println(help)

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -9,6 +9,7 @@ import (
 
 var getHelp = help.GetCmd{}
 var getConfigsHelp = help.GetConfigsCmd{}
+var getEnvironmentsHelp = help.GetEnvironmentsCmd{}
 var getRunningHelp = help.GetRunningCmd{}
 var getTemplatesHelp = help.GetTemplatesCmd{}
 var getNamespaceHelp = help.GetNamespaceCmd{}

--- a/cmd/get/get_environments.go
+++ b/cmd/get/get_environments.go
@@ -7,18 +7,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// utilitiesCmd represents the utilities command
-var utilitiesCmd = &cobra.Command{
-	Use:     "utilities",
-	Aliases: defaults.GetUtilitesAliases,
-	Short:   getUtilitiesHelp.Short(),
-	Long:    getUtilitiesHelp.Long(),
+// environmentsCmd represents the utilities command
+var environmentsCmd = &cobra.Command{
+	Use:     "environments",
+	Aliases: defaults.EnvironmentAliases,
+	Short:   getEnvironmentsHelp.Short(),
+	Long:    getEnvironmentsHelp.Long(),
 	Run: func(cmd *cobra.Command, args []string) {
+
 		additionalFields := []string{}
 		if c.ShowHidden {
 			additionalFields = append(additionalFields, []string{"HIDDEN", "REMOVE_UPSTREAM"}...)
 		}
-		c.OutputData(&c.UtilDefs, objects.TextOptions{
+		c.OutputData(&c.EnvDefs, objects.TextOptions{
 			NoHeaders:        c.NoHeaders,
 			ShowHidden:       c.ShowHidden,
 			Fields:           c.Fields,
@@ -28,5 +29,5 @@ var utilitiesCmd = &cobra.Command{
 }
 
 func init() {
-	getCmd.AddCommand(utilitiesCmd)
+	getCmd.AddCommand(environmentsCmd)
 }

--- a/cmd/launch_functions_standard.go
+++ b/cmd/launch_functions_standard.go
@@ -16,28 +16,16 @@ func standardLaunch(utility string, sa string) {
 
 	termFormatter := termenv.NewOutput(os.Stdout)
 	if c.Client != nil {
-		utilMap := make(map[string]objects.UtilityPod)
-		for _, v := range c.UtilDefs {
-			utilMap[v.Name] = objects.UtilityPod{
-				Name:              v.Name,
-				Repository:        v.Repository,
-				ExecCommand:       v.ExecCommand,
-				RequireSecrets:    v.RequireSecrets,
-				RequireConfigmaps: v.RequireConfigmaps,
-				Hint:              v.Hint,
-			}
-		}
+		utilMap := objects.GetUtilityMap(c.UtilDefs, c.EnvMap)
 
 		if utility == "" {
-			utility = ask.PromptForUtility(c.UtilDefs, c.ShowHidden)
+			utility = ask.PromptForUtility(c.UtilDefs, c.EnvMap, c.ShowHidden)
 		}
 
 		// Display the HINT
 		if len(utilMap[utility].Hint) > 0 {
 			fmt.Println(utilMap[utility].Hint)
 		}
-
-		utilRepository := utilMap[utility].Repository
 
 		namespace := c.Client.DetermineNamespace(c.Namespace)
 		if sa == "" {
@@ -76,10 +64,10 @@ func standardLaunch(utility string, sa string) {
 		osUser := os.Getenv("USER")
 		tc := &template.TemplateConfig{
 			Parameters: map[string]string{
-				"name":           fmt.Sprintf("%s-%s", utility, shortUniq),
+				"name":           fmt.Sprintf("%s-%s", utilMap[utility].Name, shortUniq),
 				"serviceAccount": sa,
 				"namespace":      namespace,
-				"registry":       utilRepository,
+				"registry":       utilMap[utility].Repository,
 				"limitsCpu":      c.SizeMap[resourceSize].LimitsCPU,
 				"limitsMem":      c.SizeMap[resourceSize].LimitsMEM,
 				"requestCpu":     c.SizeMap[resourceSize].RequestCPU,

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"fmt"
+	"ktrouble/common"
+	"ktrouble/objects"
+
+	"github.com/spf13/cobra"
+)
+
+// migrateCmd represents the migrate command
+var migrateCmd = &cobra.Command{
+	Use:   "migrate",
+	Short: migrateHelp.Short(),
+	Long:  migrateHelp.Long(),
+	Run: func(cmd *cobra.Command, args []string) {
+		if c.GitUpstream.VersionDirectoryExists(fmt.Sprintf("v%d", c.Semver.Major)) {
+			common.Logger.Error("The version directory in the repository already exists, no need to re-run the migration command")
+			return
+		}
+		fromVersion := fmt.Sprintf("v%d", c.Semver.Major-1)
+		toVersion := fmt.Sprintf("v%d", c.Semver.Major)
+		if !c.GitUpstream.Migrate(fromVersion, toVersion) {
+			common.Logger.Error("Failed to migrate the repository")
+			return
+		}
+		if !objects.MigrateLocalUtility(c.UtilDefs, toVersion) {
+			common.Logger.Error("Failed to migrate the local utility definitions")
+			return
+		}
+		if !objects.MigrateLocalEnvironments(c.EnvDefs, toVersion) {
+			common.Logger.Error("Failed to migrate the local environment definitions")
+			return
+		}
+		fmt.Println("Migration complete")
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(migrateCmd)
+}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -10,14 +10,83 @@ import (
 	"github.com/spf13/viper"
 )
 
+type PushParam struct {
+	Environments bool
+}
+
+var pushParam = PushParam{}
+
 // pushCmd represents the push command
 var pushCmd = &cobra.Command{
 	Use:   "push",
 	Short: pushHelp.Short(),
 	Long:  pushHelp.Long(),
 	Run: func(cmd *cobra.Command, args []string) {
-		pushLocalDefinitions()
+		if !c.GitUpstream.VersionDirectoryExists(fmt.Sprintf("v%d", c.Semver.Major)) {
+			if c.Semver.Major == 0 {
+				common.Logger.Error("The repository is not initialized, please create the repository usign git before running this command")
+				return
+			} else {
+				common.Logger.Error("The version directory in the repository does not exist.  Please run 'ktrouble migrate' to migrate data to the new version")
+				common.Logger.Error("The existing data will remain in the old version directory")
+				return
+			}
+		}
+		if pushParam.Environments {
+			pushLocalEnvDefinitions()
+		} else {
+			pushLocalDefinitions()
+		}
 	},
+}
+
+func pushLocalEnvDefinitions() {
+
+	// Get a list of "locals"
+	localDefs := objects.EnvironmentList{}
+
+	status := EnvironmentDefinitionStatus()
+
+	for _, v := range status {
+		def := c.EnvMap[v.Name]
+		if def.Source == "local" && !def.ExcludeFromShare {
+			def.Source = "ktrouble-utils"
+			localDefs = append(localDefs, def)
+		}
+		if def.Source != "local" && !def.ExcludeFromShare && v.Status == "different" {
+			localDefs = append(localDefs, def)
+		}
+	}
+
+	if len(localDefs) > 0 {
+		// Call gitupstream.PushLocals
+		uploadConfig := objects.EnvironmentConfig{}
+		uploadConfig.Environments = localDefs
+
+		common.Logger.Tracef("uploadConfig: \n%#v", localDefs)
+		if c.GitUpstream.PushEnvLocals(uploadConfig) {
+			for _, v := range localDefs {
+				for i, u := range c.EnvDefs {
+					if v.Name == u.Name {
+						c.EnvDefs[i].Source = "ktrouble-utils"
+						if v.RemoveUpstream {
+							c.EnvDefs = objects.RemoveEnvIndex(c.EnvDefs, i)
+						}
+						break
+					}
+				}
+			}
+			viper.Set("environments", c.EnvDefs)
+			verr := viper.WriteConfig()
+			if verr != nil {
+				common.Logger.WithError(verr).Info("Failed to write config")
+			}
+		} else {
+			common.Logger.Error("failed to push to repository")
+		}
+	} else {
+		fmt.Println("No changed definitions to push")
+	}
 }
 
 func pushLocalDefinitions() {
@@ -51,6 +120,9 @@ func pushLocalDefinitions() {
 				for i, u := range c.UtilDefs {
 					if v == u.Name {
 						c.UtilDefs[i].Source = "ktrouble-utils"
+						if c.UtilMap[v].RemoveUpstream {
+							c.UtilDefs = objects.RemoveUtilIndex(c.UtilDefs, i)
+						}
 						break
 					}
 				}
@@ -71,4 +143,5 @@ func pushLocalDefinitions() {
 
 func init() {
 	RootCmd.AddCommand(pushCmd)
+	pushCmd.Flags().BoolVar(&pushParam.Environments, "env", false, "Use this switch to operate on the environment definitions")
 }

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -2,20 +2,23 @@ package remove
 
 import (
 	"ktrouble/config"
+	"ktrouble/defaults"
 	help "ktrouble/help/remove"
 
 	"github.com/spf13/cobra"
 )
 
 var removeHelp = help.RemoveCmd{}
+var removeEnvironmentHelp = help.RemoveEnvironmentCmd{}
 var removeUtilityHelp = help.RemoveUtilityCmd{}
 
 var removeCmd = &cobra.Command{
-	Use:   "remove",
-	Args:  cobra.MinimumNArgs(1),
-	Short: removeHelp.Short(),
-	Long:  removeHelp.Long(),
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Use:     "remove",
+	Aliases: defaults.RemoveAliases,
+	Args:    cobra.MinimumNArgs(1),
+	Short:   removeHelp.Short(),
+	Long:    removeHelp.Long(),
+	Run:     func(cmd *cobra.Command, args []string) {},
 }
 
 var c *config.Config

--- a/cmd/remove/remove_environment.go
+++ b/cmd/remove/remove_environment.go
@@ -1,0 +1,76 @@
+package remove
+
+import (
+	"ktrouble/common"
+	"ktrouble/defaults"
+	"ktrouble/objects"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// environmentParam is used to store command line parameters
+var environmentParam objects.Environment
+
+// environmentCmd represents the utility command
+var environmentCmd = &cobra.Command{
+	Use:     "environment",
+	Aliases: defaults.EnvironmentAliases,
+	Short:   removeEnvironmentHelp.Short(),
+	Long:    removeEnvironmentHelp.Long(),
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(environmentParam.Name) > 0 {
+			err := removeOrHideEnvironment()
+			if err != nil {
+				logrus.WithError(err).Error("Failed to remove the environment definition")
+			}
+			if !c.FormatOverridden {
+				c.OutputFormat = "text"
+			}
+			c.OutputData(&c.EnvDefs, objects.TextOptions{
+				NoHeaders:        c.NoHeaders,
+				ShowHidden:       true,
+				Fields:           c.Fields,
+				AdditionalFields: []string{"HIDDEN", "REMOVE_UPSTREAM"},
+			})
+		}
+	},
+}
+
+func removeOrHideEnvironment() error {
+
+	updatedDefs := false
+	for i, v := range c.EnvDefs {
+		if environmentParam.Name == v.Name {
+			updatedDefs = true
+			if v.Source == "ktrouble-utils" {
+				common.Logger.WithField("name", v.Name).Tracef("Hiding environment definition")
+				c.EnvDefs[i].Hidden = true
+				if environmentParam.RemoveUpstream {
+					c.EnvDefs[i].RemoveUpstream = true
+				}
+			} else {
+				common.Logger.WithField("name", v.Name).Tracef("Removing environment definition")
+				c.EnvDefs = objects.RemoveEnvIndex(c.EnvDefs, i)
+			}
+			break
+		}
+	}
+	if updatedDefs {
+		viper.Set("environments", c.EnvDefs)
+		verr := viper.WriteConfig()
+		if verr != nil {
+			common.Logger.WithError(verr).Info("Failed to write config")
+			return verr
+		}
+	}
+
+	return nil
+}
+
+func init() {
+	removeCmd.AddCommand(environmentCmd)
+	environmentCmd.Flags().StringVarP(&environmentParam.Name, "name", "e", "", "Unique name of your environment")
+	environmentCmd.Flags().BoolVarP(&environmentParam.RemoveUpstream, "remove-upstream", "r", false, "Remove the environment from the upstream repository on next push")
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -10,24 +10,81 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type statusParams struct {
+	Environments bool
+}
+
+var statusP statusParams
+
 // statusCmd represents the status command
 var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: statusHelp.Short(),
 	Long:  statusHelp.Long(),
 	Run: func(cmd *cobra.Command, args []string) {
-		status := UtilityDefinitionStatus()
-		c.OutputData(&status, objects.TextOptions{
-			NoHeaders: c.NoHeaders,
-			Fields:    c.Fields,
-		})
+
+		if !c.GitUpstream.VersionDirectoryExists(fmt.Sprintf("v%d", c.Semver.Major)) {
+			if c.Semver.Major == 0 {
+				common.Logger.Error("The repository is not initialized, please create the repository usign git before running this command")
+				return
+			} else {
+				common.Logger.Error("The version directory in the repository does not exist.  Please run 'ktrouble migrate' to migrate data to the new version")
+				common.Logger.Error("The existing data will remain in the old version directory")
+				return
+			}
+		}
+		if statusP.Environments {
+			status := EnvironmentDefinitionStatus()
+			c.OutputData(&status, objects.TextOptions{
+				NoHeaders: c.NoHeaders,
+				Fields:    c.Fields,
+			})
+		} else {
+			status := UtilityDefinitionStatus()
+			c.OutputData(&status, objects.TextOptions{
+				NoHeaders: c.NoHeaders,
+				Fields:    c.Fields,
+			})
+		}
 	},
+}
+
+func EnvironmentDefinitionStatus() objects.StatusList {
+	status := objects.StatusList{}
+
+	remoteEnvDefs, remoteEnvDefsMap := c.GitUpstream.GetUpstreamEnvDefs()
+	for _, l := range c.EnvDefs {
+		if r, ok := remoteEnvDefsMap[l.Name]; !ok {
+			status = append(status, objects.Status{
+				Name:    l.Name,
+				Status:  "only local",
+				Exclude: fmt.Sprintf("%t", l.ExcludeFromShare),
+			})
+		} else {
+			s := compareEnvDefs(l, r)
+			status = append(status, objects.Status{
+				Name:    l.Name,
+				Status:  s,
+				Exclude: fmt.Sprintf("%t", l.ExcludeFromShare),
+			})
+		}
+	}
+	for _, r := range remoteEnvDefs {
+		if _, ok := c.EnvMap[r.Name]; !ok {
+			status = append(status, objects.Status{
+				Name:    r.Name,
+				Status:  "only remote",
+				Exclude: "",
+			})
+		}
+	}
+	return status
 }
 
 func UtilityDefinitionStatus() objects.StatusList {
 	status := objects.StatusList{}
 
-	remoteDefs, remoteDefsMap := c.GitUpstream.GetUpstreamDefs()
+	remoteDefs, remoteDefsMap, remoteEnvDefs, _ := c.GitUpstream.GetUpstreamDefs()
 
 	for _, l := range c.UtilDefs {
 		if r, ok := remoteDefsMap[l.Name]; !ok {
@@ -54,7 +111,45 @@ func UtilityDefinitionStatus() objects.StatusList {
 			})
 		}
 	}
+
+	// Check to see if there are ONLY REMOTE environment definitions
+	onlyRemoteEnv := false
+	for _, r := range remoteEnvDefs {
+		if _, ok := c.EnvMap[r.Name]; !ok {
+			onlyRemoteEnv = true
+		}
+	}
+	if onlyRemoteEnv {
+		common.Logger.Warn("There are remote environment definitions that are not in the local config.  Please run 'ktrouble status --env' and 'ktrouble pull --env' to add them to the local config")
+	}
 	return status
+}
+
+func compareEnvDefs(local objects.Environment, remote objects.Environment) string {
+	localYaml := "EnvironmentDefinition: \n  - " + unmarshallEnvDefinition(local)
+	remoteYaml := "EnvironmentDefinition: \n  - " + unmarshallEnvDefinition(remote)
+
+	origReader := bytes.NewReader([]byte(localYaml))
+	origBuffer := new(bytes.Buffer)
+	editReader := bytes.NewReader([]byte(remoteYaml))
+	editBuffer := new(bytes.Buffer)
+
+	serr := internal.SortYAML(origReader, origBuffer, 2)
+	if serr != nil {
+		common.Logger.WithError(serr).Error("Error sorting original yaml")
+	}
+	serr = internal.SortYAML(editReader, editBuffer, 2)
+	if serr != nil {
+		common.Logger.WithError(serr).Error("Error sorting edit yaml")
+	}
+
+	sortedOriginal := origBuffer.String()
+	sortedEdit := editBuffer.String()
+
+	if sortedOriginal == sortedEdit {
+		return "same"
+	}
+	return "different"
 }
 
 func compareDefs(local objects.UtilityPod, remote objects.UtilityPod) string {
@@ -86,4 +181,5 @@ func compareDefs(local objects.UtilityPod, remote objects.UtilityPod) string {
 }
 func init() {
 	RootCmd.AddCommand(statusCmd)
+	statusCmd.Flags().BoolVar(&statusP.Environments, "env", false, "Use this switch to operate on the environment definitions")
 }

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -9,6 +9,7 @@ import (
 )
 
 var updateHelp = help.UpdateCmd{}
+var updateEnvironmentHelp = help.UpdateEnvironmentCmd{}
 var updateUtilityHelp = help.UpdateUtilityCmd{}
 
 var updateCmd = &cobra.Command{

--- a/cmd/update/update_environment.go
+++ b/cmd/update/update_environment.go
@@ -1,0 +1,83 @@
+package update
+
+import (
+	"ktrouble/common"
+	"ktrouble/defaults"
+	"ktrouble/objects"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// environmentParam is used to store command line parameters
+var environmentParam objects.Environment
+
+// environmentCmd represents the utility command
+var environmentCmd = &cobra.Command{
+	Use:     "environment",
+	Aliases: defaults.EnvironmentAliases,
+	Short:   updateEnvironmentHelp.Short(),
+	Long:    updateEnvironmentHelp.Long(),
+	Run: func(cmd *cobra.Command, args []string) {
+		u, err := updateEnvironment()
+		if err != nil {
+			logrus.WithError(err).Error("Failed to update the environment definition")
+		}
+		if !c.FormatOverridden {
+			c.OutputFormat = "text"
+		}
+		updated := objects.EnvironmentList{}
+		updated = append(updated, u)
+		c.OutputData(&updated, objects.TextOptions{
+			NoHeaders: c.NoHeaders,
+			Fields:    c.Fields,
+		})
+	},
+}
+
+func updateEnvironment() (objects.Environment, error) {
+
+	updatedEnvironment := false
+	updatedDef := objects.Environment{}
+	for i, v := range c.EnvDefs {
+		common.Logger.Tracef("Checking environment: %s", v.Name)
+		if environmentParam.Name == v.Name {
+			common.Logger.Tracef("Updating environment: %s", v.Name)
+			if len(environmentParam.Repository) > 0 {
+				common.Logger.Tracef("Updating environment repository: %s", environmentParam.Repository)
+				c.EnvDefs[i].Repository = environmentParam.Repository
+				updatedEnvironment = true
+			}
+			if environmentParam.ExcludeFromShare {
+				c.EnvDefs[i].ExcludeFromShare = !c.EnvDefs[i].ExcludeFromShare
+				updatedEnvironment = true
+			}
+			if environmentParam.Hidden {
+				c.EnvDefs[i].Hidden = !c.EnvDefs[i].Hidden
+				updatedEnvironment = true
+			}
+			updatedDef = c.EnvDefs[i]
+		}
+	}
+	if updatedEnvironment {
+		viper.Set("environments", c.EnvDefs)
+		verr := viper.WriteConfig()
+		if verr != nil {
+			common.Logger.WithError(verr).Info("Failed to write config")
+			return updatedDef, verr
+		}
+	} else {
+		common.Logger.Warnf("The environment, %s, was not updated, perhaps a mis-matched name", environmentParam.Name)
+	}
+
+	return updatedDef, nil
+}
+
+func init() {
+	updateCmd.AddCommand(environmentCmd)
+	environmentCmd.Flags().StringVarP(&environmentParam.Name, "name", "e", "", "Unique name for your environment, eg: uppers or lowers")
+	environmentCmd.Flags().StringVarP(&environmentParam.Repository, "repository", "r", "", "Repository for your environment, eg: us-docker.pkg.dev/my-lower-repo")
+	environmentCmd.Flags().BoolVarP(&environmentParam.ExcludeFromShare, "toggle-exclude", "x", false, "Switch the current 'excludeFromShare' flag for the environment definition")
+	environmentCmd.Flags().BoolVar(&environmentParam.Hidden, "toggle-hidden", false, "Switch the current 'Hidden' flag for the environment definition")
+}

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ type (
 	Config struct {
 		VersionDetail       objects.Version
 		VersionJSON         string
+		Semver              SemverParts
 		OutputFormat        string
 		FormatOverridden    bool
 		NoHeaders           bool
@@ -23,6 +24,10 @@ type (
 		EnableBashLinks     bool
 		UniqIdLength        int
 		ShowHidden          bool
+		ConfigVersion       string
+		OutputDefaults      map[string][]string
+		EnvMap              map[string]objects.Environment
+		EnvDefs             objects.EnvironmentList
 		UtilMap             map[string]objects.UtilityPod
 		UtilDefs            objects.UtilityPodList
 		SizeMap             map[string]objects.ResourceSize

--- a/config/migrate.go
+++ b/config/migrate.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"fmt"
+	"io"
+	"ktrouble/common"
+	"ktrouble/defaults"
+	"ktrouble/objects"
+	"os"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+func (c *Config) MigrateLocal(toVer string) bool {
+
+	migrationSuccess := false
+	switch c.ConfigVersion {
+	case "v0":
+		for v := 1; v <= c.Semver.Major; v++ {
+			switch v {
+			case 1:
+				common.Logger.Warnf("Migrating config from v0 to v1")
+				migrationSuccess = c.UpgradeToV1()
+			}
+		}
+	}
+
+	return migrationSuccess
+}
+
+func (c *Config) UpgradeToV1() bool {
+	// Copy the config file as a backup
+	err := BackupConfig(viper.ConfigFileUsed(), fmt.Sprintf("%s-v1-upgrade-%s.bak", viper.ConfigFileUsed(), time.Now().Format("20060102-150405")))
+	if err != nil {
+		common.Logger.WithError(err).Fatal("Failed to copy config file")
+	}
+
+	// Environment Definitions are new to v1, so no migration is needed
+
+	// Utility Definitions
+	utilDefsV0 := objects.UtilityPodListV0{}
+	uerr := viper.UnmarshalKey("utilityDefinitions", &utilDefsV0)
+	if uerr != nil {
+		common.Logger.Fatal("Error unmarshalling utility defs...")
+		return false
+	}
+	if len(utilDefsV0) == 0 {
+		common.Logger.Warn("Adding default utility definitions to config.yaml")
+		seedDefs := defaults.UtilityDefinitions()
+		viper.Set("utilityDefinitions", seedDefs)
+		c.UtilDefs = defaults.UtilityDefinitions()
+		c.UtilMap = make(map[string]objects.UtilityPod, len(c.UtilDefs))
+		for _, v := range c.UtilDefs {
+			c.UtilMap[v.Name] = v
+		}
+		verr := viper.WriteConfig()
+		if verr != nil {
+			logrus.WithError(verr).Info("Failed to write config")
+		}
+	} else {
+		common.Logger.Warn("Migrating utility definitions to v1 format")
+		utilDefs := objects.UtilityPodList{}
+		uerr := viper.UnmarshalKey("utilityDefinitions", &utilDefs)
+		if uerr != nil {
+			common.Logger.Fatal("Error unmarshalling utility defs...")
+		}
+		for i := range utilDefs {
+			c.UtilDefs[i].RemoveUpstream = false
+			c.UtilDefs[i].Environments = []string{}
+		}
+		viper.Set("utilityDefinitions", c.UtilDefs)
+		verr := viper.WriteConfig()
+		if verr != nil {
+			logrus.WithError(verr).Info("Failed to write config")
+		}
+	}
+
+	return true
+}
+
+func BackupConfig(src, dest string) error {
+	common.Logger.Warnf("Backing up config file from %s to %s", src, dest)
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("failed to open source file: %w", err)
+	}
+	defer srcFile.Close()
+
+	destFile, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("failed to create destination file: %w", err)
+	}
+	defer destFile.Close()
+
+	_, err = io.Copy(destFile, srcFile)
+	if err != nil {
+		return fmt.Errorf("failed to copy file: %w", err)
+	}
+
+	return nil
+}

--- a/config/semver.go
+++ b/config/semver.go
@@ -1,4 +1,4 @@
-package common
+package config
 
 import (
 	"fmt"

--- a/defaults/constants.go
+++ b/defaults/constants.go
@@ -1,18 +1,21 @@
 package defaults
 
-var GetUtilitesAliases = []string{"utility", "utils", "util", "container", "containers", "image", "images"}
-var GetNamespacesAliases = []string{"namespaces", "ns"}
-var GetNodesAliases = []string{"nodes"}
-var GetNodeLabelsAliases = []string{"nodelabel", "nl", "labels"}
-var GetRunningAliases = []string{"pods", "pod"}
-var GetIngressesAliases = []string{"ingress", "ing"}
-var GetServicesAliases = []string{"service", "svc"}
-var GetServiceAccountsAliases = []string{"serviceaccounts", "sa"}
-var GetSizesAliases = []string{"size", "requests", "request", "limit", "limits"}
-var ChangelogAliases = []string{"cl", "changes"}
-var UpdateAliases = []string{"modify"}
-var DeleteAliases = []string{"del"}
-var GetAttachmentsAliases = []string{"attach", "att", "attachment"}
+var AddAliases = []string{"mk"}
 var AttachAliases = []string{"att", "attachment", "a"}
-var LaunchAliases = []string{"create", "apply", "pod", "l"}
+var ChangelogAliases = []string{"cl", "changes"}
+var DeleteAliases = []string{"del"}
+var EnvironmentAliases = []string{"env", "environments"}
+var GetAttachmentsAliases = []string{"attach", "att", "attachment"}
+var GetIngressesAliases = []string{"ingress", "ing"}
+var GetNamespacesAliases = []string{"namespaces", "ns"}
+var GetNodeLabelsAliases = []string{"nodelabel", "nl", "labels"}
+var GetNodesAliases = []string{"nodes"}
+var GetRunningAliases = []string{"pods", "pod"}
+var GetServiceAccountsAliases = []string{"serviceaccounts", "sa"}
+var GetServicesAliases = []string{"service", "svc"}
+var GetSizesAliases = []string{"size", "requests", "request", "limit", "limits"}
 var GetSleepAliases = []string{"ephemeral_sleep", "uptime"}
+var GetUtilitesAliases = []string{"utility", "utils", "util", "container", "containers", "image", "images"}
+var LaunchAliases = []string{"create", "apply", "pod", "l"}
+var RemoveAliases = []string{"rm"}
+var UpdateAliases = []string{"modify"}

--- a/defaults/utility_definitions.go
+++ b/defaults/utility_definitions.go
@@ -31,6 +31,8 @@ func UtilityDefinitions() []objects.UtilityPod {
 			RequireSecrets:    false,
 			RequireConfigmaps: false,
 			Hint:              utilityDefinitionHints["dnsutils"],
+			RemoveUpstream:    false,
+			Environments:      []string{},
 		},
 		{
 			Name:              "psql-curl",
@@ -42,6 +44,8 @@ func UtilityDefinitions() []objects.UtilityPod {
 			RequireSecrets:    false,
 			RequireConfigmaps: false,
 			Hint:              utilityDefinitionHints["psql-curl"],
+			RemoveUpstream:    false,
+			Environments:      []string{},
 		},
 		{
 			Name:              "psqlutils15",
@@ -53,6 +57,8 @@ func UtilityDefinitions() []objects.UtilityPod {
 			RequireSecrets:    false,
 			RequireConfigmaps: false,
 			Hint:              utilityDefinitionHints["psqlutils15"],
+			RemoveUpstream:    false,
+			Environments:      []string{},
 		},
 		{
 			Name:              "psqlutils14",
@@ -64,6 +70,8 @@ func UtilityDefinitions() []objects.UtilityPod {
 			RequireSecrets:    false,
 			RequireConfigmaps: false,
 			Hint:              utilityDefinitionHints["psqlutils14"],
+			RemoveUpstream:    false,
+			Environments:      []string{},
 		},
 		{
 			Name:              "awscli",
@@ -75,6 +83,8 @@ func UtilityDefinitions() []objects.UtilityPod {
 			RequireSecrets:    false,
 			RequireConfigmaps: false,
 			Hint:              utilityDefinitionHints["awscli"],
+			RemoveUpstream:    false,
+			Environments:      []string{},
 		},
 		{
 			Name:              "gcloudutils",
@@ -86,6 +96,8 @@ func UtilityDefinitions() []objects.UtilityPod {
 			RequireSecrets:    false,
 			RequireConfigmaps: false,
 			Hint:              utilityDefinitionHints["gcloudutils"],
+			RemoveUpstream:    false,
+			Environments:      []string{},
 		},
 		{
 			Name:              "azutils",
@@ -97,6 +109,8 @@ func UtilityDefinitions() []objects.UtilityPod {
 			RequireSecrets:    false,
 			RequireConfigmaps: false,
 			Hint:              utilityDefinitionHints["azutils"],
+			RemoveUpstream:    false,
+			Environments:      []string{},
 		},
 		{
 			Name:              "mysqlutils5",
@@ -108,6 +122,8 @@ func UtilityDefinitions() []objects.UtilityPod {
 			RequireSecrets:    false,
 			RequireConfigmaps: false,
 			Hint:              utilityDefinitionHints["mysqlutils5"],
+			RemoveUpstream:    false,
+			Environments:      []string{},
 		},
 		{
 			Name:              "mysqlutils8",
@@ -119,6 +135,8 @@ func UtilityDefinitions() []objects.UtilityPod {
 			RequireSecrets:    false,
 			RequireConfigmaps: false,
 			Hint:              utilityDefinitionHints["mysqlutils8"],
+			RemoveUpstream:    false,
+			Environments:      []string{},
 		},
 		{
 			Name:              "redis6",
@@ -130,6 +148,8 @@ func UtilityDefinitions() []objects.UtilityPod {
 			RequireSecrets:    false,
 			RequireConfigmaps: false,
 			Hint:              utilityDefinitionHints["redis6"],
+			RemoveUpstream:    false,
+			Environments:      []string{},
 		},
 		{
 			Name:              "curl",
@@ -141,6 +161,8 @@ func UtilityDefinitions() []objects.UtilityPod {
 			RequireSecrets:    false,
 			RequireConfigmaps: false,
 			Hint:              utilityDefinitionHints["curl"],
+			RemoveUpstream:    false,
+			Environments:      []string{},
 		},
 		{
 			Name:              "basic-tools",
@@ -152,6 +174,8 @@ func UtilityDefinitions() []objects.UtilityPod {
 			RequireSecrets:    false,
 			RequireConfigmaps: false,
 			Hint:              utilityDefinitionHints["basic-tools"],
+			RemoveUpstream:    false,
+			Environments:      []string{},
 		},
 	}
 

--- a/gitupstream/git.go
+++ b/gitupstream/git.go
@@ -2,7 +2,7 @@ package gitupstream
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"ktrouble/common"
 	"ktrouble/objects"
 	"os"
@@ -17,27 +17,35 @@ import (
 )
 
 type GitUpstream interface {
-	GetUpstreamDefs() (objects.UtilityPodList, map[string]objects.UtilityPod)
+	GetUpstreamDefs() (objects.UtilityPodList, map[string]objects.UtilityPod, objects.EnvironmentList, map[string]objects.Environment)
 	GetNewUpstreamDefs(localDefs objects.UtilityPodList) (objects.UtilityPodList, map[string]objects.UtilityPod)
 	PushLocals(localDefs objects.UtilityPodList) bool
+	GetUpstreamEnvDefs() (objects.EnvironmentList, map[string]objects.Environment)
+	GetNewUpstreamEnvDefs(localDefs objects.EnvironmentList) (objects.EnvironmentList, map[string]objects.Environment)
+	PushEnvLocals(localDefs objects.EnvironmentConfig) bool
+	VersionDirectoryExists(version string) bool
+	Migrate(fromVer string, toVer string) bool
 }
 
 type gitUpstream struct {
-	User   string
-	Token  string
-	GitURL string
+	User    string
+	Token   string
+	GitURL  string
+	Version string
 }
 
-func New(user string, token string, url string) GitUpstream {
+func New(user string, token string, url string, version string) GitUpstream {
 
 	return &gitUpstream{
-		User:   user,
-		Token:  token,
-		GitURL: url,
+		User:    user,
+		Token:   token,
+		GitURL:  url,
+		Version: version,
 	}
 }
 
-func (gu *gitUpstream) GetUpstreamDefs() (objects.UtilityPodList, map[string]objects.UtilityPod) {
+func (gu *gitUpstream) GetUpstreamDefs() (objects.UtilityPodList, map[string]objects.UtilityPod,
+	objects.EnvironmentList, map[string]objects.Environment) {
 
 	var storer *memory.Storage
 	var fs billy.Filesystem
@@ -58,21 +66,28 @@ func (gu *gitUpstream) GetUpstreamDefs() (objects.UtilityPodList, map[string]obj
 		common.Logger.WithError(err).Fatal("Error cloning to memory")
 	}
 
-	dirInfo, derr := fs.ReadDir("/")
+	common.Logger.Tracef("Version: %s", gu.Version)
+	rootDir := "/"
+	if gu.Version != "v0" {
+		rootDir = fmt.Sprintf("/%s/", gu.Version)
+	}
+	dirInfo, derr := fs.ReadDir(rootDir)
 	if derr != nil {
 		common.Logger.WithError(derr).Fatal("Failed to read dir")
 	}
 
 	remoteDefs := objects.UtilityPodList{}
 	remoteDefsMap := make(map[string]objects.UtilityPod, 0)
+	remoteEnvDefs := objects.EnvironmentList{}
+	remoteEnvDefsMap := make(map[string]objects.Environment, 0)
 
 	for _, di := range dirInfo {
 		if strings.HasSuffix(di.Name(), ".yaml") {
-			file, err := fs.Open(di.Name())
+			file, err := fs.Open(fmt.Sprintf("%s%s", rootDir, di.Name()))
 			if err != nil {
 				common.Logger.Errorf("failed to open file: %s", di.Name())
 			}
-			data, err := ioutil.ReadAll(file)
+			data, err := io.ReadAll(file)
 			if err != nil {
 				common.Logger.Errorf("failed to read file data from %s", di.Name())
 			}
@@ -84,12 +99,111 @@ func (gu *gitUpstream) GetUpstreamDefs() (objects.UtilityPodList, map[string]obj
 			remoteDefs = append(remoteDefs, utilDef)
 			remoteDefsMap[utilDef.Name] = utilDef
 		}
+
+		if di.Name() == "ktrouble-environments.yml" {
+			common.Logger.Tracef("Found environment definition file: %s", di.Name())
+			file, err := fs.Open(fmt.Sprintf("%s%s", rootDir, di.Name()))
+			if err != nil {
+				common.Logger.Errorf("failed to open file: %s", di.Name())
+			}
+			data, err := io.ReadAll(file)
+			if err != nil {
+				common.Logger.Errorf("failed to read file data from %s", di.Name())
+			}
+			envDefs := objects.EnvironmentConfig{}
+			merr := yaml.Unmarshal(data, &envDefs)
+			if merr != nil {
+				common.Logger.Error("failed to unmarshall utility definition")
+			}
+			remoteEnvDefs = append(remoteEnvDefs, envDefs.Environments...)
+			for _, envDef := range envDefs.Environments {
+				remoteEnvDefsMap[envDef.Name] = envDef
+			}
+		}
+
+	}
+	return remoteDefs, remoteDefsMap, remoteEnvDefs, remoteEnvDefsMap
+}
+
+func (gu *gitUpstream) GetUpstreamEnvDefs() (objects.EnvironmentList, map[string]objects.Environment) {
+
+	var storer *memory.Storage
+	var fs billy.Filesystem
+
+	storer = memory.NewStorage()
+	fs = memfs.New()
+
+	_, err := git.Clone(storer, fs, &git.CloneOptions{
+		URL: gu.GitURL,
+		Auth: &gitHttp.BasicAuth{
+			Username: gu.User,
+			Password: gu.Token,
+		},
+		Depth:    1,
+		Progress: nil,
+	})
+	if err != nil {
+		common.Logger.WithError(err).Fatal("Error cloning to memory")
+	}
+
+	common.Logger.Tracef("Version: %s", gu.Version)
+	rootDir := "/"
+	if gu.Version != "v0" {
+		rootDir = fmt.Sprintf("/%s/", gu.Version)
+	}
+	dirInfo, derr := fs.ReadDir(rootDir)
+	if derr != nil {
+		common.Logger.WithError(derr).Fatal("Failed to read dir")
+	}
+
+	remoteDefs := objects.EnvironmentList{}
+	remoteDefsMap := make(map[string]objects.Environment, 0)
+
+	for _, di := range dirInfo {
+		common.Logger.Tracef("checking file: %s", di.Name())
+		if di.Name() == "ktrouble-environments.yml" {
+			common.Logger.Tracef("Found environment definition file: %s", di.Name())
+			file, err := fs.Open(fmt.Sprintf("%s%s", rootDir, di.Name()))
+			if err != nil {
+				common.Logger.Errorf("failed to open file: %s", di.Name())
+			}
+			data, err := io.ReadAll(file)
+			if err != nil {
+				common.Logger.Errorf("failed to read file data from %s", di.Name())
+			}
+			envDefs := objects.EnvironmentConfig{}
+			merr := yaml.Unmarshal(data, &envDefs)
+			if merr != nil {
+				common.Logger.Error("failed to unmarshall utility definition")
+			}
+			remoteDefs = append(remoteDefs, envDefs.Environments...)
+			for _, envDef := range envDefs.Environments {
+				remoteDefsMap[envDef.Name] = envDef
+			}
+		}
 	}
 	return remoteDefs, remoteDefsMap
 }
+
+func (gu *gitUpstream) GetNewUpstreamEnvDefs(localDefs objects.EnvironmentList) (objects.EnvironmentList, map[string]objects.Environment) {
+
+	remoteDefs, _ := gu.GetUpstreamEnvDefs()
+
+	missingDefs := objects.EnvironmentList{}
+	allDefsMap := make(map[string]objects.Environment, 0)
+
+	for _, def := range remoteDefs {
+		if missingEnvLocally(def.Name, localDefs) {
+			missingDefs = append(missingDefs, def)
+		}
+		allDefsMap[def.Name] = def
+	}
+	return missingDefs, allDefsMap
+}
+
 func (gu *gitUpstream) GetNewUpstreamDefs(localDefs objects.UtilityPodList) (objects.UtilityPodList, map[string]objects.UtilityPod) {
 
-	remoteDefs, _ := gu.GetUpstreamDefs()
+	remoteDefs, _, _, _ := gu.GetUpstreamDefs()
 
 	missingDefs := objects.UtilityPodList{}
 	allDefsMap := make(map[string]objects.UtilityPod, 0)
@@ -101,6 +215,129 @@ func (gu *gitUpstream) GetNewUpstreamDefs(localDefs objects.UtilityPodList) (obj
 		allDefsMap[def.Name] = def
 	}
 	return missingDefs, allDefsMap
+}
+
+func (gu *gitUpstream) PushEnvLocals(envConfig objects.EnvironmentConfig) bool {
+	var storer *memory.Storage
+	var fs billy.Filesystem
+
+	storer = memory.NewStorage()
+	fs = memfs.New()
+
+	repo, err := git.Clone(storer, fs, &git.CloneOptions{
+		URL: gu.GitURL,
+		Auth: &gitHttp.BasicAuth{
+			Username: gu.User,
+			Password: gu.Token,
+		},
+		Depth:    1,
+		Progress: nil,
+	})
+	if err != nil {
+		common.Logger.WithError(err).Fatal("Error cloning to memory")
+	}
+
+	worktree, wterr := repo.Worktree()
+	if wterr != nil {
+		common.Logger.Fatal("Failed to create worktree")
+	}
+
+	common.Logger.Tracef("Version: %s", gu.Version)
+	rootDir := ""
+	if gu.Version != "v0" {
+		rootDir = fmt.Sprintf("%s/", gu.Version)
+	}
+
+	adding := []string{}
+	filename := fmt.Sprintf("%s%s", rootDir, "ktrouble-environments.yml")
+
+	// Read existing file data
+	existingEnvConfig := objects.EnvironmentConfig{}
+	file, err := fs.Open(filename)
+	if err == nil {
+		defer file.Close()
+		content, rerr := io.ReadAll(file)
+		if rerr == nil && len(content) > 0 {
+			yerr := yaml.Unmarshal(content, &existingEnvConfig)
+			if yerr != nil {
+				common.Logger.WithError(yerr).Error("Failed to unmarshal existing YAML")
+			}
+		}
+	}
+
+	addEnvs := []objects.Environment{}
+	for _, v := range envConfig.Environments {
+		common.Logger.Tracef("Adding env %s", v.Name)
+		notFound := true
+		for i, e := range existingEnvConfig.Environments {
+			if v.Name == e.Name {
+				common.Logger.Tracef("updating existing env %s", v.Name)
+				existingEnvConfig.Environments[i].Source = "ktrouble-utils"
+				existingEnvConfig.Environments[i].ExcludeFromShare = v.ExcludeFromShare
+				existingEnvConfig.Environments[i].Repository = v.Repository
+				if v.RemoveUpstream {
+					existingEnvConfig.Environments = objects.RemoveEnvIndex(existingEnvConfig.Environments, i)
+				}
+				notFound = false
+			}
+		}
+		if notFound {
+			addEnvs = append(addEnvs, v)
+		}
+	}
+	common.Logger.Tracef("Adding new environments\n%#v", addEnvs)
+	existingEnvConfig.Environments = append(existingEnvConfig.Environments, addEnvs...)
+
+	// Marshal the new envConfig into map[string]interface{}
+	newDataBytes, merr := yaml.Marshal(existingEnvConfig)
+	if merr != nil {
+		common.Logger.Fatal("Error Marshaling YAML data for write")
+	}
+
+	outFile, oerr := fs.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0666)
+	if oerr != nil {
+		common.Logger.WithError(oerr).Error("failed to open file for writing")
+		return false
+	}
+	defer outFile.Close()
+
+	_, werr := outFile.Write(newDataBytes)
+	if werr != nil {
+		common.Logger.WithError(werr).Error("failed to write to file")
+		return false
+	}
+
+	_, aerr := worktree.Add(filename)
+	if aerr != nil {
+		common.Logger.WithError(aerr).Fatal("Failed to add file")
+	}
+	adding = append(adding, filename)
+
+	// END Push to Git
+
+	status, err := worktree.Status()
+	if err != nil {
+		common.Logger.Error("failed to get worktree status")
+	}
+	fmt.Println(status.String())
+
+	_, cerr := worktree.Commit(fmt.Sprintf("%s is submitting environment definition(s): %s", gu.User, strings.Join(adding, ",")), &git.CommitOptions{})
+	if cerr != nil {
+		common.Logger.WithError(cerr).Fatal("Failed to commit changes")
+	}
+
+	perr := repo.Push(&git.PushOptions{
+		Auth: &gitHttp.BasicAuth{
+			Username: gu.User,
+			Password: gu.Token,
+		},
+		RemoteName: "origin",
+	})
+	if perr != nil {
+		common.Logger.WithError(perr).Fatal("Error pushing branch to origin")
+	}
+
+	return true
 }
 
 func (gu *gitUpstream) PushLocals(localDefs objects.UtilityPodList) bool {
@@ -129,6 +366,12 @@ func (gu *gitUpstream) PushLocals(localDefs objects.UtilityPodList) bool {
 		common.Logger.Fatal("Failed to create worktree")
 	}
 
+	common.Logger.Tracef("Version: %s", gu.Version)
+	rootDir := ""
+	if gu.Version != "v0" {
+		rootDir = fmt.Sprintf("%s/", gu.Version)
+	}
+
 	adding := []string{}
 	for _, v := range localDefs {
 
@@ -137,7 +380,7 @@ func (gu *gitUpstream) PushLocals(localDefs objects.UtilityPodList) bool {
 		if merr != nil {
 			common.Logger.Fatal("Error Marshaling YAML data for write")
 		}
-		file, err := fs.OpenFile(fmt.Sprintf("%s.yaml", v.Name), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0666)
+		file, err := fs.OpenFile(fmt.Sprintf("%s%s.yaml", rootDir, v.Name), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0666)
 		if err != nil {
 			common.Logger.WithError(err).Error("failed to open file")
 			return false
@@ -147,11 +390,14 @@ func (gu *gitUpstream) PushLocals(localDefs objects.UtilityPodList) bool {
 			common.Logger.WithError(werr).Error("failed to write to file")
 			return false
 		}
-		_, aerr := worktree.Add(fmt.Sprintf("%s.yaml", v.Name))
+		if v.RemoveUpstream {
+			fs.Remove(fmt.Sprintf("%s%s.yaml", rootDir, v.Name))
+		}
+		_, aerr := worktree.Add(fmt.Sprintf("%s%s.yaml", rootDir, v.Name))
 		if aerr != nil {
 			common.Logger.WithError(aerr).Fatal("Failed to add file")
 		}
-		adding = append(adding, v.Name)
+		adding = append(adding, fmt.Sprintf("%s%s", rootDir, v.Name))
 	}
 
 	status, err := worktree.Status()
@@ -180,6 +426,15 @@ func (gu *gitUpstream) PushLocals(localDefs objects.UtilityPodList) bool {
 }
 
 func missingLocally(name string, localDefs objects.UtilityPodList) bool {
+	for _, v := range localDefs {
+		if name == v.Name {
+			return false
+		}
+	}
+	return true
+}
+
+func missingEnvLocally(name string, localDefs objects.EnvironmentList) bool {
 	for _, v := range localDefs {
 		if name == v.Name {
 			return false

--- a/gitupstream/repository_version.go
+++ b/gitupstream/repository_version.go
@@ -1,0 +1,260 @@
+package gitupstream
+
+import (
+	"fmt"
+	"io"
+	"ktrouble/common"
+	"ktrouble/objects"
+	"os"
+	"strings"
+
+	billy "github.com/go-git/go-billy/v5"
+	memfs "github.com/go-git/go-billy/v5/memfs"
+	git "github.com/go-git/go-git/v5"
+	gitHttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+	memory "github.com/go-git/go-git/v5/storage/memory"
+	"gopkg.in/yaml.v2"
+)
+
+func (gu *gitUpstream) VersionDirectoryExists(version string) bool {
+
+	var storer *memory.Storage
+	var fs billy.Filesystem
+
+	storer = memory.NewStorage()
+	fs = memfs.New()
+
+	_, err := git.Clone(storer, fs, &git.CloneOptions{
+		URL: gu.GitURL,
+		Auth: &gitHttp.BasicAuth{
+			Username: gu.User,
+			Password: gu.Token,
+		},
+		Depth:    1,
+		Progress: nil,
+	})
+	if err != nil {
+		common.Logger.WithError(err).Fatal("Error cloning to memory")
+	}
+
+	dirInfo, derr := fs.ReadDir("/")
+	if derr != nil {
+		common.Logger.WithError(derr).Fatal("Failed to read dir")
+	}
+
+	// v0 files are simply in the root of the repo, so if we can read the dir, it exists
+	if version == "v0" {
+		return true
+	}
+
+	for _, di := range dirInfo {
+		if di.Name() == version {
+			if di.IsDir() {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (gu *gitUpstream) Migrate(fromVer string, toVer string) bool {
+	var storer *memory.Storage
+	var fs billy.Filesystem
+
+	storer = memory.NewStorage()
+	fs = memfs.New()
+
+	repo, err := git.Clone(storer, fs, &git.CloneOptions{
+		URL: gu.GitURL,
+		Auth: &gitHttp.BasicAuth{
+			Username: gu.User,
+			Password: gu.Token,
+		},
+		Depth:    1,
+		Progress: nil,
+	})
+	if err != nil {
+		common.Logger.WithError(err).Fatal("Error cloning to memory")
+	}
+
+	worktree, wterr := repo.Worktree()
+	if wterr != nil {
+		common.Logger.Fatal("Failed to create worktree")
+	}
+
+	dirInfo, derr := fs.ReadDir("/")
+	if derr != nil {
+		common.Logger.WithError(derr).Fatal("Failed to read dir")
+	}
+
+	err = fs.MkdirAll(toVer, 0755)
+	if err != nil {
+		common.Logger.WithError(err).Fatal("Failed to create version directory")
+	}
+
+	if fromVer == "v0" {
+		// Copy all files from the root to the new version directory
+		for _, di := range dirInfo {
+			if strings.HasSuffix(di.Name(), ".yaml") {
+				err = MigrateUtilityYAML(di.Name(), fs, fromVer, toVer)
+				if err != nil {
+					common.Logger.WithError(err).Fatal("Failed to migrate utility yaml")
+				}
+				_, aerr := worktree.Add(fmt.Sprintf("%s/%s", toVer, di.Name()))
+				if aerr != nil {
+					common.Logger.WithError(aerr).Fatal("Failed to add file")
+				}
+			}
+			if di.Name() == "ktrouble-environments.yml" {
+				err = MigrateEnvironmentYAML(di.Name(), fs, fromVer, toVer)
+				if err != nil {
+					common.Logger.WithError(err).Fatal("Failed to migrate utility yaml")
+				}
+				_, aerr := worktree.Add(fmt.Sprintf("%s/%s", toVer, di.Name()))
+				if aerr != nil {
+					common.Logger.WithError(aerr).Fatal("Failed to add file")
+				}
+			}
+		}
+	} else {
+		// Copy all files from the old version directory to the new version directory
+		for _, di := range dirInfo {
+			if di.Name() == fromVer {
+				if di.IsDir() {
+					oldDirInfo, err := fs.ReadDir(di.Name())
+					if err != nil {
+						common.Logger.WithError(err).Fatal("Failed to read old version dir")
+					}
+					for _, odi := range oldDirInfo {
+						if strings.HasSuffix(odi.Name(), ".yaml") {
+							common.Logger.Tracef("Migrating %s/%s to %s/%s", fromVer, odi.Name(), toVer, odi.Name())
+							err = MigrateUtilityYAML(odi.Name(), fs, fromVer, toVer)
+							if err != nil {
+								common.Logger.WithError(err).Fatal("Failed to migrate utility yaml")
+							}
+							_, aerr := worktree.Add(fmt.Sprintf("%s/%s", toVer, di.Name()))
+							if aerr != nil {
+								common.Logger.WithError(aerr).Fatal("Failed to add file")
+							}
+						}
+						if di.Name() == "ktrouble-environments.yml" {
+							err = MigrateEnvironmentYAML(di.Name(), fs, fromVer, toVer)
+							if err != nil {
+								common.Logger.WithError(err).Fatal("Failed to migrate utility yaml")
+							}
+							_, aerr := worktree.Add(fmt.Sprintf("%s/%s", toVer, di.Name()))
+							if aerr != nil {
+								common.Logger.WithError(aerr).Fatal("Failed to add file")
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	status, err := worktree.Status()
+	if err != nil {
+		common.Logger.Error("failed to get worktree status")
+	}
+	fmt.Println(status.String())
+
+	_, cerr := worktree.Commit(fmt.Sprintf("%s is migrating utility definitions: %s -> %s", gu.User, fromVer, toVer), &git.CommitOptions{})
+	if cerr != nil {
+		common.Logger.WithError(cerr).Fatal("Failed to commit changes")
+	}
+
+	perr := repo.Push(&git.PushOptions{
+		Auth: &gitHttp.BasicAuth{
+			Username: gu.User,
+			Password: gu.Token,
+		},
+		RemoteName: "origin",
+	})
+	if perr != nil {
+		common.Logger.WithError(perr).Fatal("Error pushing branch to origin")
+	}
+
+	return true
+}
+
+func MigrateUtilityYAML(filename string, fs billy.Filesystem, fromVer string, toVer string) error {
+
+	fromFile := filename
+	if fromVer != "v0" {
+		fromFile = fmt.Sprintf("%s/%s", fromVer, filename)
+	}
+	file, err := fs.Open(fromFile)
+	if err != nil {
+		common.Logger.Errorf("failed to open file: %s", filename)
+	}
+	defer file.Close()
+	data, err := io.ReadAll(file)
+	if err != nil {
+		common.Logger.Errorf("failed to read file data from %s", filename)
+	}
+	utilDef := objects.UtilityPod{}
+	merr := yaml.Unmarshal(data, &utilDef)
+	if merr != nil {
+		common.Logger.Error("failed to unmarshall utility definition")
+	}
+
+	defData, merr := yaml.Marshal(utilDef)
+	if merr != nil {
+		common.Logger.Fatal("Error Marshaling YAML data for write")
+	}
+	newFile, err := fs.OpenFile(fmt.Sprintf("%s/%s", toVer, filename), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0666)
+	if err != nil {
+		common.Logger.WithError(err).Error("failed to open file")
+		return err
+	}
+	defer newFile.Close()
+
+	_, werr := newFile.Write(defData)
+	if werr != nil {
+		common.Logger.WithError(werr).Error("failed to write to file")
+		return werr
+	}
+
+	return nil
+}
+
+func MigrateEnvironmentYAML(filename string, fs billy.Filesystem, fromVer string, toVer string) error {
+
+	fromFile := filename
+	if fromVer != "v0" {
+		fromFile = fmt.Sprintf("%s/%s", fromVer, filename)
+	}
+	file, err := fs.Open(fromFile)
+	if err != nil {
+		common.Logger.Errorf("failed to open file: %s", filename)
+	}
+	defer file.Close()
+	data, err := io.ReadAll(file)
+	if err != nil {
+		common.Logger.Errorf("failed to read file data from %s", filename)
+	}
+	envConfigDef := objects.EnvironmentConfig{}
+	merr := yaml.Unmarshal(data, &envConfigDef)
+	if merr != nil {
+		common.Logger.Error("failed to unmarshall environment definitions")
+	}
+
+	defData, merr := yaml.Marshal(envConfigDef)
+	if merr != nil {
+		common.Logger.Fatal("Error Marshaling YAML data for write")
+	}
+	newFile, err := fs.OpenFile(fmt.Sprintf("%s/%s", toVer, filename), os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0666)
+	if err != nil {
+		common.Logger.WithError(err).Error("failed to open file")
+		return err
+	}
+	defer newFile.Close()
+
+	_, werr := newFile.Write(defData)
+	if werr != nil {
+		common.Logger.WithError(werr).Error("failed to write to file")
+		return werr
+	}
+
+	return nil
+}

--- a/help/add/add_environment_help.go
+++ b/help/add/add_environment_help.go
@@ -1,0 +1,27 @@
+package add
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+)
+
+type AddEnvironmentCmd struct {
+}
+
+func (a *AddEnvironmentCmd) Short() string {
+	return "Add an environment definition to the ktrouble configuration"
+}
+
+func (a *AddEnvironmentCmd) Long() string {
+	longText := ""
+	yellow := color.New(color.FgYellow).SprintFunc()
+
+	longText += `EXAMPLE:
+  Use 'add environment' command to add a new environment definition to your 'config.yaml'
+  file`
+
+	longText = fmt.Sprintf("%s\n\n    > %s\n\n", longText, yellow(`ktrouble add environment -e 'lowers' -r 'us-docker.pkg.dev/my-lower-repo'`))
+
+	return longText
+}

--- a/help/get/get_environments_help.go
+++ b/help/get/get_environments_help.go
@@ -1,0 +1,27 @@
+package get
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+)
+
+type GetEnvironmentsCmd struct {
+}
+
+func (g *GetEnvironmentsCmd) Short() string {
+	return "Get a list of defined environments"
+}
+
+func (g *GetEnvironmentsCmd) Long() string {
+	longText := ""
+	yellow := color.New(color.FgYellow).SprintFunc()
+
+	longText += `EXAMPLE:
+  Display a list of environments defined in the configuration file
+`
+
+	longText = fmt.Sprintf("%s\n    > %s\n", longText, yellow(`ktrouble get environments`))
+
+	return longText
+}

--- a/help/migrate_help.go
+++ b/help/migrate_help.go
@@ -1,0 +1,29 @@
+package help
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+)
+
+type MigrateCmd struct {
+}
+
+func (f *MigrateCmd) Short() string {
+	return "Migrate a repostiory to the current version"
+}
+
+func (f *MigrateCmd) Long() string {
+	longText := ""
+	yellow := color.New(color.FgYellow).SprintFunc()
+
+	longText += `EXAMPLE:
+  ktrouble uses a versioned directory structure to store the data.  This command
+  will create a new version directory in the repository.  The existing data will
+  remain in the old version directory.  The new version directory will be
+  initialized with the current version data.
+`
+	longText = fmt.Sprintf("%s\n    > %s\n\n", longText, yellow(`ktrouble migrate`))
+
+	return longText
+}

--- a/help/remove/remove_environment_help.go
+++ b/help/remove/remove_environment_help.go
@@ -1,0 +1,28 @@
+package remove
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+)
+
+type RemoveEnvironmentCmd struct {
+}
+
+func (r *RemoveEnvironmentCmd) Short() string {
+	return "Remove an environment from the config file, or HIDE it if it is an upstream definition, use --remove-upstream to remove it from the upstream repository"
+}
+
+func (r *RemoveEnvironmentCmd) Long() string {
+	longText := ""
+	yellow := color.New(color.FgYellow).SprintFunc()
+
+	longText += `EXAMPLE:
+  The 'remove environment' command will prompt to select an environment definition to
+  remove from your local 'config.yaml' file
+`
+
+	longText = fmt.Sprintf("%s\n    > %s\n", longText, yellow(`ktrouble remove environment`))
+
+	return longText
+}

--- a/help/update/update_environment_help.go
+++ b/help/update/update_environment_help.go
@@ -1,0 +1,32 @@
+package update
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+)
+
+type UpdateEnvironmentCmd struct {
+}
+
+func (u *UpdateEnvironmentCmd) Short() string {
+	return "Update an existing environment definition in the local config.yaml file"
+}
+
+func (u *UpdateEnvironmentCmd) Long() string {
+	longText := ""
+	yellow := color.New(color.FgYellow).SprintFunc()
+
+	longText += `EXAMPLE:
+  Toggle the 'exclude from push' flag for an environment definition.
+`
+
+	longText = fmt.Sprintf("%s\n    > %s\n\n", longText, yellow(`ktrouble update environment -e lowers --toggle-exclude`))
+
+	longText += `EXAMPLE:
+  Change the 'repository' for the definition 'lowers' to '8675309.dkr.ecr.us-west-2.amazonaws.com'
+`
+	longText = fmt.Sprintf("%s\n    > %s\n\n", longText, yellow(`ktrouble update environment -e lower -r '8675309.dkr.ecr.us-west-2.amazonaws.com'`))
+
+	return longText
+}

--- a/objects/environments.go
+++ b/objects/environments.go
@@ -1,0 +1,187 @@
+package objects
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"ktrouble/common"
+
+	"github.com/maahsome/gron"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v2"
+)
+
+type EnvironmentConfig struct {
+	Environments EnvironmentList `json:"environments"`
+}
+
+type EnvironmentList []Environment
+
+type Environment struct {
+	Name             string `json:"name"`
+	Repository       string `json:"repository"`
+	ExcludeFromShare bool   `json:"excludefromshare"`
+	Source           string `json:"source"`
+	Hidden           bool   `json:"hidden"`
+	RemoveUpstream   bool   `json:"removeupstream"`
+}
+
+func GetEnvironmentMap(envDefs EnvironmentList) map[string]Environment {
+	envMap := make(map[string]Environment)
+
+	for _, e := range envDefs {
+		envMap[e.Name] = Environment{
+			Name:             e.Name,
+			Repository:       e.Repository,
+			ExcludeFromShare: e.ExcludeFromShare,
+		}
+	}
+	return envMap
+}
+
+func RemoveEnvIndex(s EnvironmentList, index int) EnvironmentList {
+	ret := make(EnvironmentList, 0)
+	ret = append(ret, s[:index]...)
+	return append(ret, s[index+1:]...)
+}
+
+func MigrateLocalEnvironments(u EnvironmentList, toVer string) bool {
+
+	viper.Set("environments", u)
+	verr := viper.WriteConfig()
+	if verr != nil {
+		common.Logger.WithError(verr).Info("Failed to write config")
+		return false
+	}
+
+	return true
+}
+
+func EnvironmentsExist(envMap map[string]Environment, envNames []string) bool {
+	for _, envName := range envNames {
+		common.Logger.Tracef("Checking environment: %s", envName)
+		if _, ok := envMap[envName]; !ok {
+			common.Logger.Tracef("Environment %s not found: %t", envName, ok)
+			return false
+		}
+	}
+	return true
+}
+
+// ToJSON - Write the output as JSON
+func (en *EnvironmentList) ToJSON() string {
+	envJSON, err := json.MarshalIndent(en, "", "  ")
+	if err != nil {
+		common.Logger.WithError(err).Error("Error extracting JSON")
+		return ""
+	}
+	return string(envJSON[:])
+}
+
+func (en *EnvironmentList) ToGRON() string {
+	envJSON, err := json.MarshalIndent(en, "", "  ")
+	if err != nil {
+		common.Logger.WithError(err).Error("Error extracting JSON for GRON")
+	}
+	subReader := strings.NewReader(string(envJSON[:]))
+	subValues := &bytes.Buffer{}
+	ges := gron.NewGron(subReader, subValues)
+	ges.SetMonochrome(false)
+	if serr := ges.ToGron(); serr != nil {
+		common.Logger.WithError(serr).Error("Problem generating GRON syntax")
+		return ""
+	}
+	return string(subValues.Bytes())
+}
+
+func (en *EnvironmentList) ToYAML() string {
+	envYAML, err := yaml.Marshal(en)
+	if err != nil {
+		common.Logger.WithError(err).Error("Error extracting YAML")
+		return ""
+	}
+	return string(envYAML[:])
+}
+
+func (en *EnvironmentList) ToTEXT(to TextOptions) string {
+
+	noHeaders := to.NoHeaders
+	fields := []string{}
+	if len(to.Fields) > 0 {
+		fields = append(fields, to.Fields...)
+	} else {
+		fields = []string{"NAME", "REPOSITORY", "EXCLUDED"}
+	}
+	if len(to.AdditionalFields) > 0 {
+		fields = append(fields, to.AdditionalFields...)
+	}
+	buf, row := new(bytes.Buffer), make([]string, 0)
+
+	// ************************** TableWriter ******************************
+	table := tablewriter.NewWriter(buf)
+	headerText := []string{}
+	if !noHeaders {
+		if len(to.Fields) > 0 {
+			headerText = append(headerText, to.Fields...)
+		} else {
+			headerText = []string{"NAME", "REPOSITORY", "EXCLUDED"}
+		}
+		if len(to.AdditionalFields) > 0 {
+			headerText = append(headerText, to.AdditionalFields...)
+		}
+		table.SetHeader(headerText)
+		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	}
+
+	table.SetAutoWrapText(false)
+	table.SetAutoFormatHeaders(false)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetTablePadding("\t") // pad with tabs
+	table.SetNoWhiteSpace(true)
+
+	mapList := make(map[string]Environment, len(*en))
+	nameList := []string{}
+
+	for _, v := range *en {
+		mapList[v.Name] = v
+		nameList = append(nameList, v.Name)
+	}
+
+	sort.Strings(nameList)
+
+	for _, v := range nameList {
+		row = []string{}
+
+		for _, f := range fields {
+			switch strings.ToUpper(f) {
+			case "NAME":
+				row = append(row, mapList[v].Name)
+			case "REPOSITORY":
+				row = append(row, mapList[v].Repository)
+			case "EXCLUDED":
+				row = append(row, fmt.Sprintf("%t", mapList[v].ExcludeFromShare))
+			case "HIDDEN":
+				row = append(row, fmt.Sprintf("%t", mapList[v].Hidden))
+			case "REMOVE_UPSTREAM":
+				row = append(row, fmt.Sprintf("%t", mapList[v].RemoveUpstream))
+			}
+		}
+		if !mapList[v].Hidden || to.ShowHidden {
+			table.Append(row)
+		}
+	}
+
+	table.Render()
+
+	return buf.String()
+
+}

--- a/objects/utility.go
+++ b/objects/utility.go
@@ -11,12 +11,28 @@ import (
 
 	"github.com/maahsome/gron"
 	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
 )
 
 type UtilityPodList []UtilityPod
+type UtilityPodListV0 []UtilityPodV0
 
 type UtilityPod struct {
+	Name              string   `json:"name"`
+	Repository        string   `json:"repository"`
+	ExecCommand       string   `json:"execcommand"`
+	Source            string   `json:"source"`
+	RequireSecrets    bool     `json:"requiresecrets"`
+	RequireConfigmaps bool     `json:"requireconfigmaps"`
+	ExcludeFromShare  bool     `json:"excludefromshare"`
+	Hidden            bool     `json:"hidden"`
+	Hint              string   `json:"hint"`
+	RemoveUpstream    bool     `json:"removeupstream"`
+	Environments      []string `json:"environments"`
+}
+
+type UtilityPodV0 struct {
 	Name              string `json:"name"`
 	Repository        string `json:"repository"`
 	ExecCommand       string `json:"execcommand"`
@@ -27,6 +43,52 @@ type UtilityPod struct {
 	Hidden            bool   `json:"hidden"`
 	Hint              string `json:"hint"`
 	Version           string `json:"version"`
+}
+
+func GetUtilityMap(utilDefs UtilityPodList, envMap map[string]Environment) map[string]UtilityPod {
+	utilMap := make(map[string]UtilityPod)
+	for _, v := range utilDefs {
+		if v.Environments == nil {
+			utilMap[v.Name] = UtilityPod{
+				Name:              v.Name,
+				Repository:        v.Repository,
+				ExecCommand:       v.ExecCommand,
+				RequireSecrets:    v.RequireSecrets,
+				RequireConfigmaps: v.RequireConfigmaps,
+				Hint:              v.Hint,
+			}
+		} else {
+			for _, env := range v.Environments {
+				utilMap[fmt.Sprintf("%s/%s", env, v.Name)] = UtilityPod{
+					Name:              v.Name,
+					Repository:        fmt.Sprintf("%s/%s", envMap[env].Repository, v.Repository),
+					ExecCommand:       v.ExecCommand,
+					RequireSecrets:    v.RequireSecrets,
+					RequireConfigmaps: v.RequireConfigmaps,
+					Hint:              v.Hint,
+				}
+			}
+		}
+	}
+
+	return utilMap
+}
+
+func RemoveUtilIndex(s UtilityPodList, index int) UtilityPodList {
+	ret := make(UtilityPodList, 0)
+	ret = append(ret, s[:index]...)
+	return append(ret, s[index+1:]...)
+}
+
+func MigrateLocalUtility(u UtilityPodList, toVer string) bool {
+
+	viper.Set("utilityDefinitions", u)
+	verr := viper.WriteConfig()
+	if verr != nil {
+		common.Logger.WithError(verr).Info("Failed to write config")
+		return false
+	}
+	return true
 }
 
 // ToJSON - Write the output as JSON
@@ -119,6 +181,7 @@ func (up *UtilityPodList) ToTEXT(to TextOptions) string {
 		row = []string{}
 
 		for _, f := range fields {
+			common.Logger.Tracef("Field: %s", f)
 			switch strings.ToUpper(f) {
 			case "NAME":
 				row = append(row, mapList[v].Name)
@@ -130,12 +193,16 @@ func (up *UtilityPodList) ToTEXT(to TextOptions) string {
 				row = append(row, fmt.Sprintf("%t", mapList[v].Hidden))
 			case "EXCLUDED":
 				row = append(row, fmt.Sprintf("%t", mapList[v].ExcludeFromShare))
+			case "REMOVE_UPSTREAM":
+				row = append(row, fmt.Sprintf("%t", mapList[v].RemoveUpstream))
 			case "SOURCE":
 				row = append(row, mapList[v].Source)
 			case "REQUIRESECRETS":
 				row = append(row, fmt.Sprintf("%t", mapList[v].RequireSecrets))
 			case "REQUIRECONFIGMAPS":
 				row = append(row, fmt.Sprintf("%t", mapList[v].RequireConfigmaps))
+			case "ENVIRONMENTS":
+				row = append(row, strings.Join(mapList[v].Environments, ","))
 			case "HINT":
 				row = append(row, mapList[v].Hint)
 			}


### PR DESCRIPTION
## Description

Add support for environments, which is basically a "registry" catalog, allowing the same tool definition to be pulled from multiple registries.

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [x] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
- **BREAKING** note on base feature
- Basically whatever formatting we have here, just plain-text
%> command example
- next feature
- note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

- `ktrouble` now supports `environments`, to allow a utility to be launched into different clusters that may need to pull from different image registries.
- New commands:
  - `ktrouble add environment`
  - `ktrouble get environment`
  - `ktrouble update environment`
  - `ktrouble remove environment`
  - `ktrouble migrate`
- Added versioning to the local config file, and also the upstream git repository
  - The git repository will now contain `vN` where N is the `semver.MAJOR` of the application
  - A migration process will copy the utility definitions from a previous directory to latest

### Changes

- Updated commands:
  - `ktrouble push --env` is used to push environments to upstream git repository
  - `ktrouble status --env` is used to show the status between local environment definitions and upstream definitions
  - `ktrouble diff --env` is used to view the differences in environment definitions
  - `ktrouble pull --env` is used to pull down definitions from upstream git repository
- The `pull` command has had better output added
- Updated README to include information on the `environments` feature

### Fixes

- Changed the way `ktrouble` determines if it needs a KUBECONFIG file, making it complain less

### Deprecated

### Removed

### Breaking Changes


