### PR TITLE
fix the pull -a command, was missing setting the Environments property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,4 @@ vRELEASE.md
 
 # some local stuff
 TODO.md
-.vscode/*
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,34 @@
+// You can use active debugging for ktrouble, however, the 'survey/v2' package
+// never allows me to do selections in the debugger window, so any command
+// you want to debug MUST have the ability to receive ALL parameters from the
+// command line.  I have a Jira to go through and ensure that all commands
+// can be receive ALL parameters from the command line.
+// Also, I gave up on making the ENV vars dynamic, as it seems that the
+// 'buildFlags' are not receiving the values from the ENV vars, so I just
+// update them manually.
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Debug",
+        "type": "go",
+        "request": "launch",
+        "mode": "auto",
+        "program": "${workspaceFolder}/",
+        "args": [
+          "pull",
+          "-a",
+          "--utilities",
+          "netshoot,mysql5-futurama,psql11-futurama-02"
+        ],
+        "env": {
+          "MODNAME": "ktrouble",
+          "SEMVER": "v1.0.0",         // Replace with dynamic values if desired
+          "BUILD_DATE": "2025-04-29", // Replace with dynamic values if desired
+          "GIT_COMMIT": "abc123def",  // Replace with dynamic values if desired
+          "GIT_REF": "/refs/tags/v1.0.0"
+        },
+        "buildFlags": "-ldflags='-X ktrouble/cmd.semVer=v1.0.0 -X ktrouble/cmd.buildDate=2025-05-01 -X ktrouble/cmd.gitCommit=abc12345 -X ktrouble/cmd.gitRef=tag1'"
+      }
+    ]
+  }

--- a/HELP.md
+++ b/HELP.md
@@ -1136,8 +1136,9 @@ Usage:
   ktrouble pull [flags]
 
 Flags:
-  -a, --all   Specify --all to list locally modified definitions as pull selections
-      --env   Use this switch to operate on the environment definitions
+  -a, --all                 Specify --all to list locally modified definitions as pull selections
+      --env                 Use this switch to operate on the environment definitions
+  -u, --utilities strings   Specify an array of utility names to pull: eg, --utilities 'basic-tools,dns-tools', default is to prompt
 
 Global Flags:
       --config string             config file (default is $HOME/.splicectl/config.yml)


### PR DESCRIPTION
## Description

`ktrouble pull -a` command, which pulls "different" utility definitions from the upstream repository, wasn't setting the newly created Environments property.  Also the output was only adding "added" items, and not "updated" items.

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [x] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
- **BREAKING** note on base feature
- Basically whatever formatting we have here, just plain-text
%> command example
- next feature
- note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

### Changes

- Added output to the 'ktrouble pull -a'  command to show utilities that have been "updated"

### Fixes

- When pulling existing utility definitions from upstream, I missed setting the newly created `environments` property, so the utility would remain "different" in the `ktrouble status` command.

### Deprecated

### Removed

### Breaking Changes


