### PR TITLE
Kt 90/all output fields

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -619,7 +619,7 @@ Usage:
   ktrouble get configs [flags]
 
 Aliases:
-  configs, size, requests, request, limit, limits
+  configs, config
 
 Global Flags:
       --config string             config file (default is $HOME/.splicectl/config.yml)

--- a/cmd/fields.go
+++ b/cmd/fields.go
@@ -51,7 +51,7 @@ func displayFieldHelp() {
 
   COMMAND: get service
 
-      FIELDS: NAME, NAMESPACE, TYPE, CLUSTER-IP, EXTERNAL-IP, PORT(S), LAUNCHED_BY
+      FIELDS: NAME, NAMESPACE, TYPE, CLUSTER_IP, EXTERNAL_IP, PORTS, LAUNCHED_BY
 
   COMMAND: get serviceaccount
 

--- a/cmd/fields.go
+++ b/cmd/fields.go
@@ -20,10 +20,55 @@ func displayFieldHelp() {
 
 	help := `A list of valid FIELDS that can be specified by command:
 
+  COMMAND: get|add|update|remove environment
+
+      FIELDS: NAME, REPOSITORY, EXCLUDED, HIDDEN, REMOVE_UPSTREAM
+
+  COMMAND: get ingress
+
+      FIELDS: NAME, NAMESPACE, CLASS, HOSTS, ADDRESS, PORTS, LAUNCHED_BY
+
+  COMMAND: get|add|update|remove sleep
+
+      FIELDS: NAME, SECONDS
+
   COMMAND: get|add|update|remove utility
 
       FIELDS: NAME, REPOSITORY, EXEC, HIDDEN, EXCLUDED, SOURCE, ENVIRONMENTS,
               REQUIRECONFIGMAPS, REQUIRESECRETS, HINT, REMOVE_UPSTREAM
+
+  COMMAND: get namespace
+
+      FIELDS: NAMESPACE
+
+  COMMAND: get nodes
+
+      FIELDS: NODE
+
+  COMMAND: get running
+
+      FIELDS: NAME, NAMESPACE, STATUS, LAUNCHED_BY, UTILITY, SHELL/SERVICE
+
+  COMMAND: get service
+
+      FIELDS: NAME, NAMESPACE, TYPE, CLUSTER-IP, EXTERNAL-IP, PORT(S), LAUNCHED_BY
+
+  COMMAND: get serviceaccount
+
+      FIELDS: SERVICE_ACCOUNT
+
+  COMMAND: get sizes
+
+      FIELDS: NAME, CPU_LIMIT, MEM_LIMIT, CPU_REQUEST, MEM_REQUEST
+
+  COMMAND: status
+
+      FIELDS: NAME, STATUS, EXCLUDE
+
+  COMMAND version
+
+      FIELDS: SEMVER, BUILD_DATE, GIT_COMMIT, GIT_REF
+
 `
 
 	fmt.Println(help)

--- a/cmd/get/get_configs.go
+++ b/cmd/get/get_configs.go
@@ -13,7 +13,7 @@ import (
 // configsCmd represents the templates command
 var configsCmd = &cobra.Command{
 	Use:     "configs",
-	Aliases: defaults.GetSizesAliases,
+	Aliases: defaults.GetConfigsAliases,
 	Short:   getConfigsHelp.Short(),
 	Long:    getConfigsHelp.Long(),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/get/get_ephemeral_sleep.go
+++ b/cmd/get/get_ephemeral_sleep.go
@@ -19,8 +19,11 @@ var sleepCmd = &cobra.Command{
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		c.OutputData(&c.EphemeralSleepDefs, objects.TextOptions{NoHeaders: c.NoHeaders})
-
+		c.OutputData(&c.EphemeralSleepDefs, objects.TextOptions{
+			NoHeaders:  c.NoHeaders,
+			ShowHidden: c.ShowHidden,
+			Fields:     c.Fields,
+		})
 	},
 }
 

--- a/cmd/get/get_ingresses.go
+++ b/cmd/get/get_ingresses.go
@@ -49,6 +49,7 @@ Get a list of ingresses that are installed by ktrouble
 				BashLinks:    c.EnableBashLinks,
 				UtilMap:      c.UtilMap,
 				UniqIdLength: c.UniqIdLength,
+				Fields:       c.Fields,
 			})
 		} else {
 			common.Logger.Warn("Cannot fetch installed ingresses, no valid kubernetes context")

--- a/cmd/get/get_namespace.go
+++ b/cmd/get/get_namespace.go
@@ -24,7 +24,10 @@ var namespaceCmd = &cobra.Command{
 				nsData.Namespace = append(nsData.Namespace, v.Name)
 			}
 
-			c.OutputData(&nsData, objects.TextOptions{NoHeaders: c.NoHeaders})
+			c.OutputData(&nsData, objects.TextOptions{
+				NoHeaders: c.NoHeaders,
+				Fields:    c.Fields,
+			})
 		} else {
 			common.Logger.Warn("Cannot fetch namespaces, no valid kubernetes context")
 		}

--- a/cmd/get/get_node.go
+++ b/cmd/get/get_node.go
@@ -24,7 +24,10 @@ var nodeCmd = &cobra.Command{
 				nodeData.Node = append(nodeData.Node, v.Name)
 			}
 
-			c.OutputData(&nodeData, objects.TextOptions{NoHeaders: c.NoHeaders})
+			c.OutputData(&nodeData, objects.TextOptions{
+				NoHeaders: c.NoHeaders,
+				Fields:    c.Fields,
+			})
 		} else {
 			common.Logger.Warn("Cannot fetch nodes, no valid kubernetes context")
 		}

--- a/cmd/get/get_nodelabels.go
+++ b/cmd/get/get_nodelabels.go
@@ -16,7 +16,10 @@ var nodelabelsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		nodeLabels := objects.NodeLabels{}
 		nodeLabels = c.NodeSelectorLabels
-		c.OutputData(&nodeLabels, objects.TextOptions{NoHeaders: c.NoHeaders})
+		c.OutputData(&nodeLabels, objects.TextOptions{
+			NoHeaders: c.NoHeaders,
+			Fields:    c.Fields,
+		})
 	},
 }
 

--- a/cmd/get/get_running.go
+++ b/cmd/get/get_running.go
@@ -59,6 +59,7 @@ var runningCmd = &cobra.Command{
 				BashLinks:    c.EnableBashLinks,
 				UtilMap:      c.UtilMap,
 				UniqIdLength: c.UniqIdLength,
+				Fields:       c.Fields,
 			})
 		} else {
 			common.Logger.Warn("Cannot fetch running pods, no valid kubernetes context")

--- a/cmd/get/get_serviceaccount.go
+++ b/cmd/get/get_serviceaccount.go
@@ -25,7 +25,10 @@ var serviceaccountCmd = &cobra.Command{
 				saData.ServiceAccount = append(saData.ServiceAccount, v.Name)
 			}
 
-			c.OutputData(&saData, objects.TextOptions{NoHeaders: c.NoHeaders})
+			c.OutputData(&saData, objects.TextOptions{
+				NoHeaders: c.NoHeaders,
+				Fields:    c.Fields,
+			})
 		} else {
 			common.Logger.Warn("Cannot fetch service accounts, no valid kubernetes context")
 		}

--- a/cmd/get/get_services.go
+++ b/cmd/get/get_services.go
@@ -53,6 +53,7 @@ Get a list of services that are installed by ktrouble
 				BashLinks:    c.EnableBashLinks,
 				UtilMap:      c.UtilMap,
 				UniqIdLength: c.UniqIdLength,
+				Fields:       c.Fields,
 			})
 		} else {
 			common.Logger.Warn("Cannot fetch installed services, no valid kubernetes context")

--- a/cmd/get/get_sizes.go
+++ b/cmd/get/get_sizes.go
@@ -15,8 +15,10 @@ var sizesCmd = &cobra.Command{
 	Long:    getSizesHelp.Long(),
 	Run: func(cmd *cobra.Command, args []string) {
 
-		c.OutputData(&c.SizeDefs, objects.TextOptions{NoHeaders: c.NoHeaders})
-
+		c.OutputData(&c.SizeDefs, objects.TextOptions{
+			NoHeaders: c.NoHeaders,
+			Fields:    c.Fields,
+		})
 	},
 }
 

--- a/cmd/launch_functions_standard.go
+++ b/cmd/launch_functions_standard.go
@@ -142,7 +142,7 @@ func standardLaunch(p launchParam) {
 				"host":           p.Host,
 				"targetPort":     fmt.Sprintf("%d", p.Port),
 				"path":           p.Path,
-				"associatedPod":  fmt.Sprintf("%s-%s", utility, shortUniq),
+				"associatedPod":  fmt.Sprintf("%s-%s", utilMap[utility].Name, shortUniq),
 			},
 			Secrets:    selectedSecrets,
 			ConfigMaps: selectedConfigMaps,

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -23,7 +23,10 @@ var versionCmd = &cobra.Command{
 		if !c.FormatOverridden {
 			c.OutputFormat = "json"
 		}
-		c.OutputData(&version, objects.TextOptions{NoHeaders: c.NoHeaders})
+		c.OutputData(&version, objects.TextOptions{
+			NoHeaders: c.NoHeaders,
+			Fields:    c.Fields,
+		})
 	},
 }
 

--- a/defaults/aliases.go
+++ b/defaults/aliases.go
@@ -6,6 +6,7 @@ var ChangelogAliases = []string{"cl", "changes"}
 var DeleteAliases = []string{"del"}
 var EnvironmentAliases = []string{"env", "environments"}
 var GetAttachmentsAliases = []string{"attach", "att", "attachment"}
+var GetConfigsAliases = []string{"config"}
 var GetIngressesAliases = []string{"ingress", "ing"}
 var GetNamespacesAliases = []string{"namespaces", "ns"}
 var GetNodeLabelsAliases = []string{"nodelabel", "nl", "labels"}

--- a/objects/environments.go
+++ b/objects/environments.go
@@ -109,31 +109,20 @@ func (en *EnvironmentList) ToYAML() string {
 
 func (en *EnvironmentList) ToTEXT(to TextOptions) string {
 
-	noHeaders := to.NoHeaders
-	fields := []string{}
-	if len(to.Fields) > 0 {
-		fields = append(fields, to.Fields...)
-	} else {
-		fields = []string{"NAME", "REPOSITORY", "EXCLUDED"}
-	}
-	if len(to.AdditionalFields) > 0 {
-		fields = append(fields, to.AdditionalFields...)
-	}
 	buf, row := new(bytes.Buffer), make([]string, 0)
-
-	// ************************** TableWriter ******************************
 	table := tablewriter.NewWriter(buf)
-	headerText := []string{}
-	if !noHeaders {
+	fields := []string{}
+	if !to.NoHeaders {
 		if len(to.Fields) > 0 {
-			headerText = append(headerText, to.Fields...)
+			upperFields := fieldsToUpper(to.Fields)
+			fields = append(fields, upperFields...)
 		} else {
-			headerText = []string{"NAME", "REPOSITORY", "EXCLUDED"}
+			fields = []string{"NAME", "REPOSITORY", "EXCLUDED"}
 		}
 		if len(to.AdditionalFields) > 0 {
-			headerText = append(headerText, to.AdditionalFields...)
+			fields = append(fields, to.AdditionalFields...)
 		}
-		table.SetHeader(headerText)
+		table.SetHeader(fields)
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	}
 

--- a/objects/ephemeral_sleep.go
+++ b/objects/ephemeral_sleep.go
@@ -56,20 +56,24 @@ func (es *EphemeralSleepList) ToYAML() string {
 
 func (es *EphemeralSleepList) ToTEXT(to TextOptions) string {
 
-	noHeaders := to.NoHeaders
-
 	buf, row := new(bytes.Buffer), make([]string, 0)
-
-	// ************************** TableWriter ******************************
 	table := tablewriter.NewWriter(buf)
-	if !noHeaders {
-		headerText := []string{"NAME", "SECONDS"}
-		table.SetHeader(headerText)
+	fields := []string{}
+	if !to.NoHeaders {
+		if len(to.Fields) > 0 {
+			fields = append(fields, to.Fields...)
+		} else {
+			fields = []string{"NAME", "SECONDS"}
+		}
+		if len(to.AdditionalFields) > 0 {
+			fields = append(fields, to.AdditionalFields...)
+		}
+		table.SetHeader(fields)
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	}
 
 	table.SetAutoWrapText(false)
-	table.SetAutoFormatHeaders(false)
+	table.SetAutoFormatHeaders(true)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetCenterSeparator("")
 	table.SetColumnSeparator("")
@@ -88,9 +92,14 @@ func (es *EphemeralSleepList) ToTEXT(to TextOptions) string {
 	}
 
 	for _, v := range nameList {
-		row = []string{
-			mapList[v].Name,
-			mapList[v].Seconds,
+		row = []string{}
+		for _, f := range fields {
+			switch strings.ToUpper(f) {
+			case "NAME":
+				row = append(row, mapList[v].Name)
+			case "SECONDS":
+				row = append(row, mapList[v].Seconds)
+			}
 		}
 		table.Append(row)
 	}

--- a/objects/helpers.go
+++ b/objects/helpers.go
@@ -1,0 +1,11 @@
+package objects
+
+import "strings"
+
+func fieldsToUpper(fields []string) []string {
+	upperFields := make([]string, len(fields))
+	for i, field := range fields {
+		upperFields[i] = strings.ToUpper(field)
+	}
+	return upperFields
+}

--- a/objects/ingress.go
+++ b/objects/ingress.go
@@ -61,15 +61,20 @@ func (i *IngressList) ToYAML() string {
 
 func (i *IngressList) ToTEXT(to TextOptions) string {
 
-	noHeaders := to.NoHeaders
-
 	buf, row := new(bytes.Buffer), make([]string, 0)
-
-	// ************************** TableWriter ******************************
 	table := tablewriter.NewWriter(buf)
-	if !noHeaders {
-		headerText := []string{"NAME", "NAMESPACE", "CLASS", "URL", "ADDRESS", "PORTS", "LAUNCHED_BY"}
-		table.SetHeader(headerText)
+	fields := []string{}
+	if !to.NoHeaders {
+		if len(to.Fields) > 0 {
+			upperFields := fieldsToUpper(to.Fields)
+			fields = append(fields, upperFields...)
+		} else {
+			fields = []string{"NAME", "NAMESPACE", "CLASS", "URL", "ADDRESS", "PORTS", "LAUNCHED_BY"}
+		}
+		if len(to.AdditionalFields) > 0 {
+			fields = append(fields, to.AdditionalFields...)
+		}
+		table.SetHeader(fields)
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	}
 
@@ -85,14 +90,24 @@ func (i *IngressList) ToTEXT(to TextOptions) string {
 	table.SetNoWhiteSpace(true)
 
 	for _, v := range *i {
-		row = []string{
-			v.Name,
-			v.Namespace,
-			v.Class,
-			v.Hosts,
-			v.Address,
-			v.Ports,
-			v.LaunchedBy,
+		row = []string{}
+		for _, f := range fields {
+			switch strings.ToUpper(f) {
+			case "NAME":
+				row = append(row, v.Name)
+			case "NAMESPACE":
+				row = append(row, v.Namespace)
+			case "CLASS":
+				row = append(row, v.Class)
+			case "URL":
+				row = append(row, v.Hosts)
+			case "ADDRESS":
+				row = append(row, v.Address)
+			case "PORTS":
+				row = append(row, v.Ports)
+			case "LAUNCHED_BY":
+				row = append(row, v.LaunchedBy)
+			}
 		}
 		table.Append(row)
 	}

--- a/objects/namespace.go
+++ b/objects/namespace.go
@@ -53,15 +53,18 @@ func (n *NamespaceList) ToYAML() string {
 
 func (n *NamespaceList) ToTEXT(to TextOptions) string {
 
-	noHeaders := to.NoHeaders
-
 	buf := new(bytes.Buffer)
 	var row []string
-
-	// ************************** TableWriter ******************************
 	table := tablewriter.NewWriter(buf)
-	if !noHeaders {
-		table.SetHeader([]string{"NAMESPACE"})
+	fields := []string{}
+	if !to.NoHeaders {
+		if len(to.Fields) > 0 {
+			upperFields := fieldsToUpper(to.Fields)
+			fields = append(fields, upperFields...)
+		} else {
+			fields = []string{"NAMESPACE"}
+		}
+		table.SetHeader(fields)
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	}
 
@@ -77,8 +80,12 @@ func (n *NamespaceList) ToTEXT(to TextOptions) string {
 	table.SetNoWhiteSpace(true)
 
 	for _, v := range n.Namespace {
-		row = []string{
-			v,
+		row = []string{}
+		for _, f := range fields {
+			switch strings.ToUpper(f) {
+			case "NAMESPACE":
+				row = append(row, v)
+			}
 		}
 		table.Append(row)
 	}

--- a/objects/node.go
+++ b/objects/node.go
@@ -53,15 +53,19 @@ func (n *NodeList) ToYAML() string {
 
 func (n *NodeList) ToTEXT(to TextOptions) string {
 
-	noHeaders := to.NoHeaders
-
 	buf := new(bytes.Buffer)
 	var row []string
-
-	// ************************** TableWriter ******************************
 	table := tablewriter.NewWriter(buf)
-	if !noHeaders {
-		table.SetHeader([]string{"NODE"})
+	fields := []string{}
+
+	if !to.NoHeaders {
+		if len(to.Fields) > 0 {
+			upperFields := fieldsToUpper(to.Fields)
+			fields = append(fields, upperFields...)
+		} else {
+			fields = []string{"NODE"}
+		}
+		table.SetHeader(fields)
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	}
 
@@ -77,8 +81,12 @@ func (n *NodeList) ToTEXT(to TextOptions) string {
 	table.SetNoWhiteSpace(true)
 
 	for _, v := range n.Node {
-		row = []string{
-			v,
+		row = []string{}
+		for _, f := range fields {
+			switch strings.ToUpper(f) {
+			case "NODE":
+				row = append(row, v)
+			}
 		}
 		table.Append(row)
 	}

--- a/objects/nodelabels.go
+++ b/objects/nodelabels.go
@@ -51,15 +51,18 @@ func (nl *NodeLabels) ToYAML() string {
 
 func (nl *NodeLabels) ToTEXT(to TextOptions) string {
 
-	noHeaders := to.NoHeaders
-
 	buf, row := new(bytes.Buffer), make([]string, 0)
-
-	// ************************** TableWriter ******************************
 	table := tablewriter.NewWriter(buf)
-	if !noHeaders {
-		headerText := []string{"LABEL"}
-		table.SetHeader(headerText)
+	fields := []string{}
+
+	if !to.NoHeaders {
+		if len(to.Fields) > 0 {
+			upperFields := fieldsToUpper(to.Fields)
+			fields = append(fields, upperFields...)
+		} else {
+			fields = []string{"LABEL"}
+		}
+		table.SetHeader(fields)
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	}
 
@@ -75,8 +78,12 @@ func (nl *NodeLabels) ToTEXT(to TextOptions) string {
 	table.SetNoWhiteSpace(true)
 
 	for _, v := range *nl {
-		row = []string{
-			v,
+		row = []string{}
+		for _, f := range fields {
+			switch strings.ToUpper(f) {
+			case "LABEL":
+				row = append(row, v)
+			}
 		}
 		table.Append(row)
 	}

--- a/objects/service.go
+++ b/objects/service.go
@@ -62,15 +62,19 @@ func (s *ServiceList) ToYAML() string {
 
 func (s *ServiceList) ToTEXT(to TextOptions) string {
 
-	noHeaders := to.NoHeaders
-
 	buf, row := new(bytes.Buffer), make([]string, 0)
+	table := tablewriter.NewWriter(buf)
+	fields := []string{}
 
 	// ************************** TableWriter ******************************
-	table := tablewriter.NewWriter(buf)
-	if !noHeaders {
-		headerText := []string{"NAME", "NAMESPACE", "TYPE", "CLUSTER-IP", "EXTERNAL-IP", "PORT(S)", "LAUNCHED_BY"}
-		table.SetHeader(headerText)
+	if !to.NoHeaders {
+		if len(to.Fields) > 0 {
+			upperFields := fieldsToUpper(to.Fields)
+			fields = append(fields, upperFields...)
+		} else {
+			fields = []string{"NAME", "NAMESPACE", "TYPE", "CLUSTER-IP", "EXTERNAL-IP", "PORT(S)", "LAUNCHED_BY"}
+		}
+		table.SetHeader(fields)
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	}
 
@@ -86,14 +90,24 @@ func (s *ServiceList) ToTEXT(to TextOptions) string {
 	table.SetNoWhiteSpace(true)
 
 	for _, v := range *s {
-		row = []string{
-			v.Name,
-			v.Namespace,
-			v.ServiceType,
-			v.ClusterIP,
-			v.ExternalIP,
-			v.Ports,
-			v.LaunchedBy,
+		row = []string{}
+		for _, f := range fields {
+			switch strings.ToUpper(f) {
+			case "NAME":
+				row = append(row, v.Name)
+			case "NAMESPACE":
+				row = append(row, v.Namespace)
+			case "TYPE":
+				row = append(row, v.ServiceType)
+			case "CLUSTER-IP":
+				row = append(row, v.ClusterIP)
+			case "EXTERNAL-IP":
+				row = append(row, v.ExternalIP)
+			case "PORT(S)":
+				row = append(row, v.Ports)
+			case "LAUNCHED_BY":
+				row = append(row, v.LaunchedBy)
+			}
 		}
 		table.Append(row)
 	}

--- a/objects/service.go
+++ b/objects/service.go
@@ -72,7 +72,7 @@ func (s *ServiceList) ToTEXT(to TextOptions) string {
 			upperFields := fieldsToUpper(to.Fields)
 			fields = append(fields, upperFields...)
 		} else {
-			fields = []string{"NAME", "NAMESPACE", "TYPE", "CLUSTER-IP", "EXTERNAL-IP", "PORT(S)", "LAUNCHED_BY"}
+			fields = []string{"NAME", "NAMESPACE", "TYPE", "CLUSTER_IP", "EXTERNAL_IP", "PORTS", "LAUNCHED_BY"}
 		}
 		table.SetHeader(fields)
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
@@ -99,11 +99,11 @@ func (s *ServiceList) ToTEXT(to TextOptions) string {
 				row = append(row, v.Namespace)
 			case "TYPE":
 				row = append(row, v.ServiceType)
-			case "CLUSTER-IP":
+			case "CLUSTER_IP":
 				row = append(row, v.ClusterIP)
-			case "EXTERNAL-IP":
+			case "EXTERNAL_IP":
 				row = append(row, v.ExternalIP)
-			case "PORT(S)":
+			case "PORTS":
 				row = append(row, v.Ports)
 			case "LAUNCHED_BY":
 				row = append(row, v.LaunchedBy)

--- a/objects/serviceaccount.go
+++ b/objects/serviceaccount.go
@@ -53,14 +53,20 @@ func (sa *ServiceAccountList) ToYAML() string {
 
 func (sa *ServiceAccountList) ToTEXT(to TextOptions) string {
 
-	noHeaders := to.NoHeaders
 	buf := new(bytes.Buffer)
 	var row []string
+	table := tablewriter.NewWriter(buf)
+	fields := []string{}
 
 	// ************************** TableWriter ******************************
-	table := tablewriter.NewWriter(buf)
-	if !noHeaders {
-		table.SetHeader([]string{"SERVICE_ACCOUNT"})
+	if !to.NoHeaders {
+		if len(to.Fields) > 0 {
+			upperFields := fieldsToUpper(to.Fields)
+			fields = append(fields, upperFields...)
+		} else {
+			fields = []string{"SERVICE_ACCOUNT"}
+		}
+		table.SetHeader(fields)
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	}
 
@@ -76,8 +82,12 @@ func (sa *ServiceAccountList) ToTEXT(to TextOptions) string {
 	table.SetNoWhiteSpace(true)
 
 	for _, v := range sa.ServiceAccount {
-		row = []string{
-			v,
+		row = []string{}
+		for _, f := range fields {
+			switch strings.ToUpper(f) {
+			case "SERVICE_ACCOUNT":
+				row = append(row, v)
+			}
 		}
 		table.Append(row)
 	}

--- a/objects/size.go
+++ b/objects/size.go
@@ -59,15 +59,19 @@ func (rs *ResourceSizeList) ToYAML() string {
 
 func (rs *ResourceSizeList) ToTEXT(to TextOptions) string {
 
-	noHeaders := to.NoHeaders
-
 	buf, row := new(bytes.Buffer), make([]string, 0)
+	table := tablewriter.NewWriter(buf)
+	fields := []string{}
 
 	// ************************** TableWriter ******************************
-	table := tablewriter.NewWriter(buf)
-	if !noHeaders {
-		headerText := []string{"NAME", "CPU_LIMIT", "MEM_LIMIT", "CPU_REQUEST", "MEM_REQUEST"}
-		table.SetHeader(headerText)
+	if !to.NoHeaders {
+		if len(to.Fields) > 0 {
+			upperFields := fieldsToUpper(to.Fields)
+			fields = append(fields, upperFields...)
+		} else {
+			fields = []string{"NAME", "CPU_LIMIT", "MEM_LIMIT", "CPU_REQUEST", "MEM_REQUEST"}
+		}
+		table.SetHeader(fields)
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	}
 
@@ -91,12 +95,20 @@ func (rs *ResourceSizeList) ToTEXT(to TextOptions) string {
 	}
 
 	for _, v := range nameList {
-		row = []string{
-			mapList[v].Name,
-			mapList[v].LimitsCPU,
-			mapList[v].LimitsMEM,
-			mapList[v].RequestCPU,
-			mapList[v].RequestMEM,
+		row = []string{}
+		for _, f := range fields {
+			switch strings.ToUpper(f) {
+			case "NAME":
+				row = append(row, mapList[v].Name)
+			case "CPU_LIMIT":
+				row = append(row, mapList[v].LimitsCPU)
+			case "MEM_LIMIT":
+				row = append(row, mapList[v].LimitsMEM)
+			case "CPU_REQUEST":
+				row = append(row, mapList[v].RequestCPU)
+			case "MEM_REQUEST":
+				row = append(row, mapList[v].RequestMEM)
+			}
 		}
 		table.Append(row)
 	}

--- a/objects/status.go
+++ b/objects/status.go
@@ -57,15 +57,20 @@ func (s *StatusList) ToYAML() string {
 
 func (s *StatusList) ToTEXT(to TextOptions) string {
 
-	noHeaders := to.NoHeaders
-
 	buf := new(bytes.Buffer)
 	var row []string
+	table := tablewriter.NewWriter(buf)
+	fields := []string{}
 
 	// ************************** TableWriter ******************************
-	table := tablewriter.NewWriter(buf)
-	if !noHeaders {
-		table.SetHeader([]string{"NAME", "STATUS", "PUSH_EXCLUDE"})
+	if !to.NoHeaders {
+		if len(to.Fields) > 0 {
+			upperFields := fieldsToUpper(to.Fields)
+			fields = append(fields, upperFields...)
+		} else {
+			fields = []string{"NAME", "STATUS", "PUSH_EXCLUDE"}
+		}
+		table.SetHeader(fields)
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	}
 
@@ -81,10 +86,16 @@ func (s *StatusList) ToTEXT(to TextOptions) string {
 	table.SetNoWhiteSpace(true)
 
 	for _, v := range *s {
-		row = []string{
-			v.Name,
-			v.Status,
-			v.Exclude,
+		row = []string{}
+		for _, f := range fields {
+			switch strings.ToUpper(f) {
+			case "NAME":
+				row = append(row, v.Name)
+			case "STATUS":
+				row = append(row, v.Status)
+			case "EXCLUDE":
+				row = append(row, v.Exclude)
+			}
 		}
 		table.Append(row)
 	}

--- a/objects/utility.go
+++ b/objects/utility.go
@@ -128,31 +128,21 @@ func (up *UtilityPodList) ToYAML() string {
 
 func (up *UtilityPodList) ToTEXT(to TextOptions) string {
 
-	noHeaders := to.NoHeaders
-	fields := []string{}
-	if len(to.Fields) > 0 {
-		fields = append(fields, to.Fields...)
-	} else {
-		fields = []string{"NAME", "REPOSITORY", "EXEC"}
-	}
-	if len(to.AdditionalFields) > 0 {
-		fields = append(fields, to.AdditionalFields...)
-	}
 	buf, row := new(bytes.Buffer), make([]string, 0)
-
-	// ************************** TableWriter ******************************
 	table := tablewriter.NewWriter(buf)
-	headerText := []string{}
-	if !noHeaders {
+	fields := []string{}
+
+	if !to.NoHeaders {
 		if len(to.Fields) > 0 {
-			headerText = append(headerText, to.Fields...)
+			upperFields := fieldsToUpper(to.Fields)
+			fields = append(fields, upperFields...)
 		} else {
-			headerText = []string{"NAME", "REPOSITORY", "EXEC"}
+			fields = []string{"NAME", "REPOSITORY", "EXEC"}
 		}
 		if len(to.AdditionalFields) > 0 {
-			headerText = append(headerText, to.AdditionalFields...)
+			fields = append(fields, to.AdditionalFields...)
 		}
-		table.SetHeader(headerText)
+		table.SetHeader(fields)
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	}
 
@@ -181,7 +171,6 @@ func (up *UtilityPodList) ToTEXT(to TextOptions) string {
 		row = []string{}
 
 		for _, f := range fields {
-			common.Logger.Tracef("Field: %s", f)
 			switch strings.ToUpper(f) {
 			case "NAME":
 				row = append(row, mapList[v].Name)

--- a/objects/version.go
+++ b/objects/version.go
@@ -55,20 +55,25 @@ func (v *Version) ToYAML() string {
 
 func (v *Version) ToTEXT(to TextOptions) string {
 
-	noHeaders := to.NoHeaders
-
 	buf := new(bytes.Buffer)
 	var row []string
+	table := tablewriter.NewWriter(buf)
+	fields := []string{}
 
 	// ************************** TableWriter ******************************
-	table := tablewriter.NewWriter(buf)
-	if !noHeaders {
-		table.SetHeader([]string{"COMPONENT", "VERSION"})
+	if !to.NoHeaders {
+		if len(to.Fields) > 0 {
+			upperFields := fieldsToUpper(to.Fields)
+			fields = append(fields, upperFields...)
+		} else {
+			fields = []string{"SEMVER", "BUILD_DATE", "GIT_COMMIT", "GIT_REF"}
+		}
+		table.SetHeader(fields)
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	}
 
 	table.SetAutoWrapText(false)
-	table.SetAutoFormatHeaders(true)
+	table.SetAutoFormatHeaders(false)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetCenterSeparator("")
 	table.SetColumnSeparator("")
@@ -78,13 +83,19 @@ func (v *Version) ToTEXT(to TextOptions) string {
 	table.SetTablePadding("\t") // pad with tabs
 	table.SetNoWhiteSpace(true)
 
-	row = []string{"Version", v.SemVer}
-	table.Append(row)
-	row = []string{"BuildDate", v.BuildDate}
-	table.Append(row)
-	row = []string{"GitCommit", v.GitCommit}
-	table.Append(row)
-	row = []string{"GitRef", v.GitRef}
+	row = []string{}
+	for _, f := range fields {
+		switch strings.ToUpper(f) {
+		case "SEMVER":
+			row = append(row, v.SemVer)
+		case "BUILD_DATE":
+			row = append(row, v.BuildDate)
+		case "GIT_COMMIT":
+			row = append(row, v.GitCommit)
+		case "GIT_REF":
+			row = append(row, v.GitRef)
+		}
+	}
 	table.Append(row)
 
 	table.Render()


### PR DESCRIPTION
## Description

Add the `--fields` selection support to all of the output items.

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [x] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
- **BREAKING** note on base feature
- Basically whatever formatting we have here, just plain-text
%> command example
- next feature
- note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

- All commands with table formatted output `-o text` now support `--fields` CSV list of field names
- Use `ktrouble fields` to get a list of supported fields for each command

### Changes

### Fixes

### Deprecated

### Removed

### Breaking Changes


