### PR TITLE
add field outputs to the config file

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -22,6 +22,7 @@
 - [get namespace](#get-namespace)
 - [get node](#get-node)
 - [get nodelabels](#get-nodelabels)
+- [get output-fields](#get-output-fields)
 - [get running](#get-running)
 - [get serviceaccount](#get-serviceaccount)
 - [get services](#get-services)
@@ -38,6 +39,7 @@
 - [remove utility](#remove-utility)
 - [set](#set)
 - [set config](#set-config)
+- [set output-fields](#set-output-fields)
 - [status](#status)
 - [update](#update)
 - [update environment](#update-environment)
@@ -528,6 +530,7 @@ Available Commands:
   namespace      Get a list of namespaces
   node           Get a list of node labels
   nodelabels     Get a list of defined node labels in config.yaml
+  output-fields  Get a list fo the current output fields definitions
   running        Get a list of running pods
   serviceaccount Get a list of K8s ServiceAccount(s) in a Namespace
   services       Get a list of ktrouble installed services
@@ -773,6 +776,36 @@ Usage:
 
 Aliases:
   nodelabels, nodelabel, nl, labels
+
+Global Flags:
+      --config string             config file (default is $HOME/.splicectl/config.yml)
+  -f, --fields strings            Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
+      --ingress-template string   Specify the ingress template file to use to render the INGRESS manifest, for --create-ingress option (default "default-ingress")
+      --log-file string           Set the logging level: trace,debug,info,warning,error,fatal
+  -v, --log-level string          Set the logging level: trace,debug,info,warning,error,fatal
+  -n, --namespace string          Specify the namespace to run in, ENV NAMESPACE then -n for preference
+      --no-headers                Suppress header output in Text output
+  -o, --output string             output types: json, text, yaml, gron, raw
+      --service-template string   Specify the service template file to use to render the SERVICE manifest, for --create-ingress option (default "default-service")
+  -s, --show-hidden               Show entries with the 'hidden' property set to 'true'
+  -t, --template string           Specify the template file to use to render the POD manifest (default "default")
+```
+
+[TOC](#TOC)
+
+## get output-fields
+
+```plaintext
+EXAMPLE:
+  Display a list of output definition names and their related fields from the configuration file
+
+    > ktrouble get output-fields
+
+Usage:
+  ktrouble get output-fields [flags]
+
+Aliases:
+  output-fields, of, fields, field, output-field
 
 Global Flags:
       --config string             config file (default is $HOME/.splicectl/config.yml)
@@ -1057,7 +1090,7 @@ EXAMPLE:
   All of the above examples prompt for all the missing parameters.  You can also specify ALL of the
   parameters on the command line, and optionally just return the POD name.
 
-  All of these parameters, except or node-selecotr, need to be set if you want to suppress the prompts.
+  All of these parameters, except or node-selector, need to be set if you want to suppress the prompts.
 
   Parameters:
     - --utility/-u <name>           : The name of the utility to launch, must match the utility name
@@ -1332,7 +1365,8 @@ Usage:
   ktrouble set [command]
 
 Available Commands:
-  config      Set configuration options for ktrouble
+  config        Set configuration options for ktrouble
+  output-fields Set default output fields for ktrouble commands
 
 Global Flags:
       --config string             config file (default is $HOME/.splicectl/config.yml)
@@ -1408,6 +1442,74 @@ Flags:
 Global Flags:
       --config string             config file (default is $HOME/.splicectl/config.yml)
   -f, --fields strings            Specify an array of field names: eg, --fields 'NAME,REPOSITORY'
+      --ingress-template string   Specify the ingress template file to use to render the INGRESS manifest, for --create-ingress option (default "default-ingress")
+      --log-file string           Set the logging level: trace,debug,info,warning,error,fatal
+  -v, --log-level string          Set the logging level: trace,debug,info,warning,error,fatal
+  -n, --namespace string          Specify the namespace to run in, ENV NAMESPACE then -n for preference
+      --no-headers                Suppress header output in Text output
+  -o, --output string             output types: json, text, yaml, gron, raw
+      --service-template string   Specify the service template file to use to render the SERVICE manifest, for --create-ingress option (default "default-service")
+  -s, --show-hidden               Show entries with the 'hidden' property set to 'true'
+  -t, --template string           Specify the template file to use to render the POD manifest (default "default")
+```
+
+[TOC](#TOC)
+
+## set output-fields
+
+```plaintext
+EXAMPLE:
+  Set the default output field for 'environment' commands to 'name,repository,source,hidden'.
+
+    > ktrouble set output-fields --output-name environments --fields 'name,repository,excluded,hidden'
+
+EXAMPLE:
+  Set the default output for 'pod' commands to 'name,launched_by'
+
+    > ktrouble set output-fields --output-name pod --fields 'name,launched_by'
+
+EXAMPLE:
+  Reset to the default output fields for 'pod' commands.
+
+    > ktrouble set output-fields --output-name pod --fields ''
+
+EXAMPLE:
+  The possible --output-name and --field combinations are:
+
+  Output Names/Fields:
+
+    - environments   : NAME,  REPOSITORY,  EXCLUDED,  HIDDEN,  REMOVE_UPSTREAM
+    - ephemeral_sleep: NAME,  SECONDS
+    - ingress        : NAME,  NAMESPACE,  CLASS,  HOSTS,  ADDRESS
+                       PORTS,  LAUNCHED_BY
+    - namespace      : NAMESPACE
+    - node           : NODE
+    - node_labels    : LABEL
+    - output_fields  : NAME,  FIELDS
+    - pod            : NAME,  NAMESPACE,  STATUS,  LAUNCHED_BY,  UTILITY
+                       SHELL/SERVICE
+    - service        : NAME,  NAMESPACE,  TYPE,  CLUSTER_IP,  EXTERNAL_IP
+                       PORTS,  LAUNCHED_BY
+    - service_account: SERVICE_ACCOUNT
+    - size           : NAME,  CPU_LIMIT,  MEM_LIMIT,  CPU_REQUEST,  MEM_REQUEST
+    - status         : NAME,  STATUS,  EXCLUDE
+    - utility        : NAME,  REPOSITORY,  EXEC,  HIDDEN,  EXCLUDED
+                       SOURCE,  ENVIRONMENTS,  REQUIRECONFIGMAPS,  REQUIRESECRETS,  HINT
+                       REMOVE_UPSTREAM
+    - version        : SEMVER,  BUILD_DATE,  GIT_COMMIT,  GIT_REF
+
+Usage:
+  ktrouble set output-fields [flags]
+
+Aliases:
+  output-fields, of, fields, field, output-field
+
+Flags:
+      --fields strings       Comma-separated list of fields to set for the output (e.g., name,repository,source,hidden); 'default' to set to default fields
+      --output-name string   The name of the output to set the fields for (e.g., pod, environment, utility, etc.)
+
+Global Flags:
+      --config string             config file (default is $HOME/.splicectl/config.yml)
       --ingress-template string   Specify the ingress template file to use to render the INGRESS manifest, for --create-ingress option (default "default-ingress")
       --log-file string           Set the logging level: trace,debug,info,warning,error,fatal
   -v, --log-level string          Set the logging level: trace,debug,info,warning,error,fatal

--- a/cmd/add/add_environment.go
+++ b/cmd/add/add_environment.go
@@ -30,8 +30,9 @@ var environmentCmd = &cobra.Command{
 			added := objects.EnvironmentList{}
 			added = append(added, u)
 			c.OutputData(&added, objects.TextOptions{
-				NoHeaders: c.NoHeaders,
-				Fields:    c.Fields,
+				NoHeaders:     c.NoHeaders,
+				Fields:        c.Fields,
+				DefaultFields: c.OutputFieldsMap["environments"],
 			})
 		} else {
 			common.Logger.Error("Parameters passed in have failed checks.  Please review the warnings above")
@@ -72,9 +73,10 @@ func checkAddEnvironmentParams() bool {
 					c.OutputFormat = "text"
 				}
 				c.OutputData(&u, objects.TextOptions{
-					NoHeaders:  c.NoHeaders,
-					ShowHidden: c.ShowHidden,
-					Fields:     c.Fields,
+					NoHeaders:     c.NoHeaders,
+					ShowHidden:    c.ShowHidden,
+					Fields:        c.Fields,
+					DefaultFields: c.OutputFieldsMap["environments"],
 				})
 			}
 		}

--- a/cmd/add/add_utility.go
+++ b/cmd/add/add_utility.go
@@ -35,6 +35,7 @@ var utilityCmd = &cobra.Command{
 				ShowHidden:       c.ShowHidden,
 				Fields:           c.Fields,
 				AdditionalFields: []string{"EXCLUDED"},
+				DefaultFields:    c.OutputFieldsMap["utility"],
 			})
 		} else {
 			common.Logger.Error("Parameters passed in have failed checks.  Please review the warnings above")
@@ -89,9 +90,10 @@ func checkAddUtilityParams() bool {
 					c.OutputFormat = "text"
 				}
 				c.OutputData(&u, objects.TextOptions{
-					NoHeaders:  c.NoHeaders,
-					ShowHidden: c.ShowHidden,
-					Fields:     c.Fields,
+					NoHeaders:     c.NoHeaders,
+					ShowHidden:    c.ShowHidden,
+					Fields:        c.Fields,
+					DefaultFields: c.OutputFieldsMap["utility"],
 				})
 			}
 		}

--- a/cmd/fields.go
+++ b/cmd/fields.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"ktrouble/defaults"
 
 	"github.com/spf13/cobra"
 )
@@ -18,58 +19,67 @@ var fieldsCmd = &cobra.Command{
 
 func displayFieldHelp() {
 
+	validFields := defaults.ValidOutputFields()
 	help := `A list of valid FIELDS that can be specified by command:
 
   COMMAND: get|add|update|remove environment
-
-      FIELDS: NAME, REPOSITORY, EXCLUDED, HIDDEN, REMOVE_UPSTREAM
+`
+	help += fmt.Sprintf("      FIELDS: %s", validFields["environment"])
+	help += `
 
   COMMAND: get ingress
-
-      FIELDS: NAME, NAMESPACE, CLASS, HOSTS, ADDRESS, PORTS, LAUNCHED_BY
+`
+	help += fmt.Sprintf("      FIELDS: %s", validFields["ingress"])
+	help += `
 
   COMMAND: get|add|update|remove sleep
-
-      FIELDS: NAME, SECONDS
+`
+	help += fmt.Sprintf("      FIELDS: %s", validFields["ephemeral_sleep"])
+	help += `
 
   COMMAND: get|add|update|remove utility
-
-      FIELDS: NAME, REPOSITORY, EXEC, HIDDEN, EXCLUDED, SOURCE, ENVIRONMENTS,
-              REQUIRECONFIGMAPS, REQUIRESECRETS, HINT, REMOVE_UPSTREAM
+`
+	help += fmt.Sprintf("      FIELDS: %s", validFields["utility"])
+	help += `
 
   COMMAND: get namespace
-
-      FIELDS: NAMESPACE
+`
+	help += fmt.Sprintf("      FIELDS: %s", validFields["namespace"])
+	help += `
 
   COMMAND: get nodes
-
-      FIELDS: NODE
+`
+	help += fmt.Sprintf("      FIELDS: %s", validFields["node_labels"])
+	help += `
 
   COMMAND: get running
-
-      FIELDS: NAME, NAMESPACE, STATUS, LAUNCHED_BY, UTILITY, SHELL/SERVICE
+`
+	help += fmt.Sprintf("      FIELDS: %s", validFields["pod"])
+	help += `
 
   COMMAND: get service
-
-      FIELDS: NAME, NAMESPACE, TYPE, CLUSTER_IP, EXTERNAL_IP, PORTS, LAUNCHED_BY
+`
+	help += fmt.Sprintf("      FIELDS: %s", validFields["service"])
+	help += `
 
   COMMAND: get serviceaccount
-
-      FIELDS: SERVICE_ACCOUNT
+`
+	help += fmt.Sprintf("      FIELDS: %s", validFields["service_account"])
+	help += `
 
   COMMAND: get sizes
-
-      FIELDS: NAME, CPU_LIMIT, MEM_LIMIT, CPU_REQUEST, MEM_REQUEST
+`
+	help += fmt.Sprintf("      FIELDS: %s", validFields["size"])
+	help += `
 
   COMMAND: status
-
-      FIELDS: NAME, STATUS, EXCLUDE
+`
+	help += fmt.Sprintf("      FIELDS: %s", validFields["status"])
+	help += `
 
   COMMAND version
-
-      FIELDS: SEMVER, BUILD_DATE, GIT_COMMIT, GIT_REF
-
 `
+	help += fmt.Sprintf("      FIELDS: %s", validFields["version"])
 
 	fmt.Println(help)
 }

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -15,6 +15,7 @@ var getTemplatesHelp = help.GetTemplatesCmd{}
 var getNamespaceHelp = help.GetNamespaceCmd{}
 var getNodeHelp = help.GetNodeCmd{}
 var getNodeLabelsHelp = help.GetNodeLabelsCmd{}
+var getOutputFieldsHelp = help.GetOutputFieldsCmd{}
 var getServiceAccountHelp = help.GetServiceAccountCmd{}
 var getSizesHelp = help.GetSizesCmd{}
 var getUtilitiesHelp = help.GetUtilitiesCmd{}

--- a/cmd/get/get_attachments.go
+++ b/cmd/get/get_attachments.go
@@ -57,10 +57,11 @@ var attachmentsCmd = &cobra.Command{
 			}
 
 			c.OutputData(&podData, objects.TextOptions{
-				NoHeaders:    c.NoHeaders,
-				BashLinks:    c.EnableBashLinks,
-				UtilMap:      c.UtilMap,
-				UniqIdLength: c.UniqIdLength,
+				NoHeaders:     c.NoHeaders,
+				BashLinks:     c.EnableBashLinks,
+				UtilMap:       c.UtilMap,
+				UniqIdLength:  c.UniqIdLength,
+				DefaultFields: c.OutputFieldsMap["pod"],
 			})
 		} else {
 			common.Logger.Warn("Cannot fetch attached containers, no valid kubernetes context")

--- a/cmd/get/get_environments.go
+++ b/cmd/get/get_environments.go
@@ -24,6 +24,7 @@ var environmentsCmd = &cobra.Command{
 			ShowHidden:       c.ShowHidden,
 			Fields:           c.Fields,
 			AdditionalFields: additionalFields,
+			DefaultFields:    c.OutputFieldsMap["environments"],
 		})
 	},
 }

--- a/cmd/get/get_ephemeral_sleep.go
+++ b/cmd/get/get_ephemeral_sleep.go
@@ -20,9 +20,10 @@ var sleepCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 
 		c.OutputData(&c.EphemeralSleepDefs, objects.TextOptions{
-			NoHeaders:  c.NoHeaders,
-			ShowHidden: c.ShowHidden,
-			Fields:     c.Fields,
+			NoHeaders:     c.NoHeaders,
+			ShowHidden:    c.ShowHidden,
+			Fields:        c.Fields,
+			DefaultFields: c.OutputFieldsMap["ephemeral_sleep"],
 		})
 	},
 }

--- a/cmd/get/get_ingresses.go
+++ b/cmd/get/get_ingresses.go
@@ -45,11 +45,12 @@ Get a list of ingresses that are installed by ktrouble
 			}
 
 			c.OutputData(&ingressData, objects.TextOptions{
-				NoHeaders:    c.NoHeaders,
-				BashLinks:    c.EnableBashLinks,
-				UtilMap:      c.UtilMap,
-				UniqIdLength: c.UniqIdLength,
-				Fields:       c.Fields,
+				NoHeaders:     c.NoHeaders,
+				BashLinks:     c.EnableBashLinks,
+				UtilMap:       c.UtilMap,
+				UniqIdLength:  c.UniqIdLength,
+				Fields:        c.Fields,
+				DefaultFields: c.OutputFieldsMap["ingress"],
 			})
 		} else {
 			common.Logger.Warn("Cannot fetch installed ingresses, no valid kubernetes context")

--- a/cmd/get/get_namespace.go
+++ b/cmd/get/get_namespace.go
@@ -25,8 +25,9 @@ var namespaceCmd = &cobra.Command{
 			}
 
 			c.OutputData(&nsData, objects.TextOptions{
-				NoHeaders: c.NoHeaders,
-				Fields:    c.Fields,
+				NoHeaders:     c.NoHeaders,
+				Fields:        c.Fields,
+				DefaultFields: c.OutputFieldsMap["namespace"],
 			})
 		} else {
 			common.Logger.Warn("Cannot fetch namespaces, no valid kubernetes context")

--- a/cmd/get/get_node.go
+++ b/cmd/get/get_node.go
@@ -25,8 +25,9 @@ var nodeCmd = &cobra.Command{
 			}
 
 			c.OutputData(&nodeData, objects.TextOptions{
-				NoHeaders: c.NoHeaders,
-				Fields:    c.Fields,
+				NoHeaders:     c.NoHeaders,
+				Fields:        c.Fields,
+				DefaultFields: c.OutputFieldsMap["node"],
 			})
 		} else {
 			common.Logger.Warn("Cannot fetch nodes, no valid kubernetes context")

--- a/cmd/get/get_nodelabels.go
+++ b/cmd/get/get_nodelabels.go
@@ -17,8 +17,9 @@ var nodelabelsCmd = &cobra.Command{
 		nodeLabels := objects.NodeLabels{}
 		nodeLabels = c.NodeSelectorLabels
 		c.OutputData(&nodeLabels, objects.TextOptions{
-			NoHeaders: c.NoHeaders,
-			Fields:    c.Fields,
+			NoHeaders:     c.NoHeaders,
+			Fields:        c.Fields,
+			DefaultFields: c.OutputFieldsMap["node_labels"],
 		})
 	},
 }

--- a/cmd/get/get_output_fields.go
+++ b/cmd/get/get_output_fields.go
@@ -1,0 +1,28 @@
+package get
+
+import (
+	"ktrouble/defaults"
+	"ktrouble/objects"
+
+	"github.com/spf13/cobra"
+)
+
+// outputFieldsCmd
+var outputFieldsCmd = &cobra.Command{
+	Use:     "output-fields",
+	Aliases: defaults.OutputFieldsAliases,
+	Short:   getOutputFieldsHelp.Short(),
+	Long:    getOutputFieldsHelp.Long(),
+	Run: func(cmd *cobra.Command, args []string) {
+
+		c.OutputData(&c.OutputFieldsDefs, objects.TextOptions{
+			NoHeaders:     c.NoHeaders,
+			Fields:        c.Fields,
+			DefaultFields: c.OutputFieldsMap["output_fields"],
+		})
+	},
+}
+
+func init() {
+	getCmd.AddCommand(outputFieldsCmd)
+}

--- a/cmd/get/get_running.go
+++ b/cmd/get/get_running.go
@@ -55,11 +55,12 @@ var runningCmd = &cobra.Command{
 			}
 
 			c.OutputData(&podData, objects.TextOptions{
-				NoHeaders:    c.NoHeaders,
-				BashLinks:    c.EnableBashLinks,
-				UtilMap:      c.UtilMap,
-				UniqIdLength: c.UniqIdLength,
-				Fields:       c.Fields,
+				NoHeaders:     c.NoHeaders,
+				BashLinks:     c.EnableBashLinks,
+				UtilMap:       c.UtilMap,
+				UniqIdLength:  c.UniqIdLength,
+				Fields:        c.Fields,
+				DefaultFields: c.OutputFieldsMap["pod"],
 			})
 		} else {
 			common.Logger.Warn("Cannot fetch running pods, no valid kubernetes context")

--- a/cmd/get/get_serviceaccount.go
+++ b/cmd/get/get_serviceaccount.go
@@ -26,8 +26,9 @@ var serviceaccountCmd = &cobra.Command{
 			}
 
 			c.OutputData(&saData, objects.TextOptions{
-				NoHeaders: c.NoHeaders,
-				Fields:    c.Fields,
+				NoHeaders:     c.NoHeaders,
+				Fields:        c.Fields,
+				DefaultFields: c.OutputFieldsMap["service_account"],
 			})
 		} else {
 			common.Logger.Warn("Cannot fetch service accounts, no valid kubernetes context")

--- a/cmd/get/get_services.go
+++ b/cmd/get/get_services.go
@@ -49,11 +49,12 @@ Get a list of services that are installed by ktrouble
 			}
 
 			c.OutputData(&serviceData, objects.TextOptions{
-				NoHeaders:    c.NoHeaders,
-				BashLinks:    c.EnableBashLinks,
-				UtilMap:      c.UtilMap,
-				UniqIdLength: c.UniqIdLength,
-				Fields:       c.Fields,
+				NoHeaders:     c.NoHeaders,
+				BashLinks:     c.EnableBashLinks,
+				UtilMap:       c.UtilMap,
+				UniqIdLength:  c.UniqIdLength,
+				Fields:        c.Fields,
+				DefaultFields: c.OutputFieldsMap["service"],
 			})
 		} else {
 			common.Logger.Warn("Cannot fetch installed services, no valid kubernetes context")

--- a/cmd/get/get_sizes.go
+++ b/cmd/get/get_sizes.go
@@ -16,8 +16,9 @@ var sizesCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 
 		c.OutputData(&c.SizeDefs, objects.TextOptions{
-			NoHeaders: c.NoHeaders,
-			Fields:    c.Fields,
+			NoHeaders:     c.NoHeaders,
+			Fields:        c.Fields,
+			DefaultFields: c.OutputFieldsMap["size"],
 		})
 	},
 }

--- a/cmd/get/get_utilities.go
+++ b/cmd/get/get_utilities.go
@@ -23,6 +23,7 @@ var utilitiesCmd = &cobra.Command{
 			ShowHidden:       c.ShowHidden,
 			Fields:           c.Fields,
 			AdditionalFields: additionalFields,
+			DefaultFields:    c.OutputFieldsMap["utility"],
 		})
 	},
 }

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -38,16 +38,18 @@ var pullCmd = &cobra.Command{
 			status := pullEnvironmentDefinitions()
 			if len(status) > 0 {
 				c.OutputData(&status, objects.TextOptions{
-					NoHeaders: c.NoHeaders,
-					Fields:    c.Fields,
+					NoHeaders:     c.NoHeaders,
+					Fields:        c.Fields,
+					DefaultFields: c.OutputFieldsMap["environments"],
 				})
 			}
 		} else {
 			status := pullUtilityDefinitions()
 			if len(status) > 0 {
 				c.OutputData(&status, objects.TextOptions{
-					NoHeaders: c.NoHeaders,
-					Fields:    c.Fields,
+					NoHeaders:     c.NoHeaders,
+					Fields:        c.Fields,
+					DefaultFields: c.OutputFieldsMap["environments"],
 				})
 			}
 		}

--- a/cmd/remove/remove_environment.go
+++ b/cmd/remove/remove_environment.go
@@ -33,7 +33,10 @@ var environmentCmd = &cobra.Command{
 				ShowHidden:       true,
 				Fields:           c.Fields,
 				AdditionalFields: []string{"HIDDEN", "REMOVE_UPSTREAM"},
+				DefaultFields:    c.OutputFieldsMap["environments"],
 			})
+		} else {
+			logrus.Warn("--name/-e environment name must be specified")
 		}
 	},
 }

--- a/cmd/remove/remove_utility.go
+++ b/cmd/remove/remove_utility.go
@@ -33,6 +33,7 @@ var utilityCmd = &cobra.Command{
 				ShowHidden:       true,
 				Fields:           c.Fields,
 				AdditionalFields: []string{"HIDDEN", "REMOVE_UPSTREAM"},
+				DefaultFields:    c.OutputFieldsMap["utility"],
 			})
 		}
 	},

--- a/cmd/set/set.go
+++ b/cmd/set/set.go
@@ -9,6 +9,7 @@ import (
 
 var setHelp = help.SetCmd{}
 var setConfigHelp = help.SetConfigCmd{}
+var setOutputFieldsHelp = help.SetOutputFieldsCmd{}
 
 var setCmd = &cobra.Command{
 	Use:   "set",

--- a/cmd/set/set_output_fields.go
+++ b/cmd/set/set_output_fields.go
@@ -1,0 +1,122 @@
+package set
+
+import (
+	"ktrouble/common"
+	"ktrouble/defaults"
+	"ktrouble/objects"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type configFieldsParam struct {
+	Name   string
+	Fields []string
+}
+
+var fieldsP configFieldsParam
+
+// setOutputFieldsCmd
+var setOutputFieldsCmd = &cobra.Command{
+	Use:     "output-fields",
+	Aliases: defaults.OutputFieldsAliases,
+	Short:   setOutputFieldsHelp.Short(),
+	Long:    setOutputFieldsHelp.Long(),
+	Run: func(cmd *cobra.Command, args []string) {
+
+		if validateOutputFieldsParams() {
+			if validateFieldNames(fieldsP) {
+				if strings.ToLower(fieldsP.Fields[0]) == "default" {
+					common.Logger.Warnf("Setting output fields for '%s' to default fields", fieldsP.Name)
+					setOutputFieldsToDefault(fieldsP.Name)
+				} else {
+					common.Logger.Warnf("Setting output fields for '%s' to: %s", fieldsP.Name, strings.Join(fieldsP.Fields, ", "))
+					setOutputFields(fieldsP)
+				}
+			}
+		}
+	},
+}
+
+func setOutputFields(param configFieldsParam) {
+	// We have the defs in the config
+	currentFieldDefs := c.OutputFieldsDefs
+	newFieldDefs := objects.OutputFieldsList{}
+	for _, def := range currentFieldDefs {
+		if def.Name == param.Name {
+			// Set the fields
+			def.Fields = strings.ReplaceAll(strings.ToUpper(strings.Join(param.Fields, ",")), " ", "")
+			newFieldDefs = append(newFieldDefs, def)
+		} else {
+			newFieldDefs = append(newFieldDefs, def)
+		}
+	}
+	c.OutputFieldsDefs = newFieldDefs
+	c.OutputFieldsMap[param.Name] = param.Fields
+	viper.Set("outputFields", c.OutputFieldsDefs)
+	verr := viper.WriteConfig()
+	if verr != nil {
+		logrus.WithError(verr).Info("Failed to write config")
+	}
+}
+
+func setOutputFieldsToDefault(name string) {
+	// We have the defs in the config
+	currentFieldDefs := c.OutputFieldsDefs
+	newFieldDefs := objects.OutputFieldsList{}
+	for _, def := range currentFieldDefs {
+		if def.Name == name {
+			// Set to default fields
+			def.Fields = strings.ReplaceAll(defaults.OutputNamesList()[name], " ", "")
+			newFieldDefs = append(newFieldDefs, def)
+		} else {
+			newFieldDefs = append(newFieldDefs, def)
+		}
+	}
+	c.OutputFieldsDefs = newFieldDefs
+	c.OutputFieldsMap[name] = strings.Split(defaults.ValidOutputFields()[name], ",")
+	viper.Set("outputFields", c.OutputFieldsDefs)
+	verr := viper.WriteConfig()
+	if verr != nil {
+		logrus.WithError(verr).Info("Failed to write config")
+	}
+}
+
+func validateFieldNames(params configFieldsParam) bool {
+	if len(params.Fields) == 1 && strings.ToLower(params.Fields[0]) == "default" {
+		return true
+	}
+
+	validFields, fieldList := defaults.ValidFieldNamesForOutputName(params.Name)
+
+	for _, field := range params.Fields {
+		if _, ok := validFields[strings.TrimSpace(strings.ToUpper(field))]; !ok {
+			common.Logger.Warnf("Invalid field name: %s", field)
+			common.Logger.Warnf("Valid fields for '%s': %s", params.Name, fieldList)
+			return false
+		}
+	}
+	return true
+}
+
+// validateOutputFieldsParams checks if the required parameters for setting output fields are provided.
+func validateOutputFieldsParams() bool {
+	if fieldsP.Name == "" {
+		common.Logger.Warn("--output-name is required")
+		return false
+	}
+	if len(fieldsP.Fields) == 0 {
+		common.Logger.Warn("--fields is required")
+		return false
+	}
+	return true
+}
+
+func init() {
+	setCmd.AddCommand(setOutputFieldsCmd)
+
+	setOutputFieldsCmd.Flags().StringVar(&fieldsP.Name, "output-name", "", "The name of the output to set the fields for (e.g., pod, environment, utility, etc.)")
+	setOutputFieldsCmd.Flags().StringSliceVar(&fieldsP.Fields, "fields", []string{}, "Comma-separated list of fields to set for the output (e.g., name,repository,source,hidden); 'default' to set to default fields")
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -36,14 +36,16 @@ var statusCmd = &cobra.Command{
 		if statusP.Environments {
 			status := EnvironmentDefinitionStatus()
 			c.OutputData(&status, objects.TextOptions{
-				NoHeaders: c.NoHeaders,
-				Fields:    c.Fields,
+				NoHeaders:     c.NoHeaders,
+				Fields:        c.Fields,
+				DefaultFields: c.OutputFieldsMap["status"],
 			})
 		} else {
 			status := UtilityDefinitionStatus()
 			c.OutputData(&status, objects.TextOptions{
-				NoHeaders: c.NoHeaders,
-				Fields:    c.Fields,
+				NoHeaders:     c.NoHeaders,
+				Fields:        c.Fields,
+				DefaultFields: c.OutputFieldsMap["status"],
 			})
 		}
 	},

--- a/cmd/update/update_environment.go
+++ b/cmd/update/update_environment.go
@@ -30,8 +30,9 @@ var environmentCmd = &cobra.Command{
 		updated := objects.EnvironmentList{}
 		updated = append(updated, u)
 		c.OutputData(&updated, objects.TextOptions{
-			NoHeaders: c.NoHeaders,
-			Fields:    c.Fields,
+			NoHeaders:     c.NoHeaders,
+			Fields:        c.Fields,
+			DefaultFields: c.OutputFieldsMap["environments"],
 		})
 	},
 }

--- a/cmd/update/update_utility.go
+++ b/cmd/update/update_utility.go
@@ -36,6 +36,7 @@ var utilityCmd = &cobra.Command{
 				ShowHidden:       true,
 				Fields:           c.Fields,
 				AdditionalFields: []string{"ENVIRONMENTS", "HIDDEN", "EXCLUDED", "REQUIRECONFIGMAPS", "REQUIRESECRETS"},
+				DefaultFields:    c.OutputFieldsMap["utility"],
 			})
 		} else {
 			common.Logger.Error("Parameters passed in have failed checks.  Please review the warnings above")
@@ -80,9 +81,10 @@ func checkUpdateUtilityParams() bool {
 					c.OutputFormat = "text"
 				}
 				c.OutputData(&u, objects.TextOptions{
-					NoHeaders:  c.NoHeaders,
-					ShowHidden: c.ShowHidden,
-					Fields:     c.Fields,
+					NoHeaders:     c.NoHeaders,
+					ShowHidden:    c.ShowHidden,
+					Fields:        c.Fields,
+					DefaultFields: c.OutputFieldsMap["utility"],
 				})
 			}
 		}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -24,8 +24,9 @@ var versionCmd = &cobra.Command{
 			c.OutputFormat = "json"
 		}
 		c.OutputData(&version, objects.TextOptions{
-			NoHeaders: c.NoHeaders,
-			Fields:    c.Fields,
+			NoHeaders:     c.NoHeaders,
+			Fields:        c.Fields,
+			DefaultFields: c.OutputFieldsMap["version"],
 		})
 	},
 }

--- a/config/config.go
+++ b/config/config.go
@@ -46,6 +46,8 @@ type (
 		IngressTemplateFile string
 		EphemeralSleepMap   map[string]objects.EphemeralSleep
 		EphemeralSleepDefs  objects.EphemeralSleepList
+		OutputFieldsDefs    objects.OutputFieldsList
+		OutputFieldsMap     map[string][]string
 	}
 
 	Outputtable interface {

--- a/defaults/aliases.go
+++ b/defaults/aliases.go
@@ -18,5 +18,6 @@ var GetSizesAliases = []string{"size", "requests", "request", "limit", "limits"}
 var GetSleepAliases = []string{"ephemeral_sleep", "uptime"}
 var GetUtilitesAliases = []string{"utility", "utils", "util", "container", "containers", "image", "images"}
 var LaunchAliases = []string{"create", "apply", "pod", "l"}
+var OutputFieldsAliases = []string{"of", "fields", "field", "output-field"}
 var RemoveAliases = []string{"rm"}
 var UpdateAliases = []string{"modify"}

--- a/defaults/output_fields.go
+++ b/defaults/output_fields.go
@@ -1,0 +1,123 @@
+package defaults
+
+import (
+	"ktrouble/objects"
+	"strings"
+)
+
+func MissingConfigOutputFieldDefinitions(confDefs map[string][]string) []string {
+	missing := make([]string, 0)
+	for k, v := range OutputNamesList() {
+		if _, ok := confDefs[k]; !ok {
+			missing = append(missing, k)
+		} else {
+			if len(v) == 0 {
+				missing = append(missing, k)
+			}
+		}
+	}
+	return missing
+}
+
+func OutputNamesList() map[string]string {
+	outputs := OutputFieldsList()
+	names := make(map[string]string, len(outputs))
+	for _, output := range outputs {
+		names[output.Name] = output.Fields
+	}
+	return names
+}
+
+func ValidFieldNamesForOutputName(name string) (map[string]string, string) {
+	validFields := ValidOutputFields()
+	if fields, ok := validFields[name]; ok {
+		fieldList := strings.Split(fields, ",")
+		fieldMap := make(map[string]string, len(fieldList))
+		for _, field := range fieldList {
+			fieldMap[strings.TrimSpace(field)] = field
+		}
+		return fieldMap, fields
+	}
+	return nil, ""
+}
+
+func ValidOutputFields() map[string]string {
+	return map[string]string{
+		"environments":    "NAME, REPOSITORY, EXCLUDED, HIDDEN, REMOVE_UPSTREAM",
+		"ephemeral_sleep": "NAME, SECONDS",
+		"ingress":         "NAME, NAMESPACE, CLASS, HOSTS, ADDRESS, PORTS, LAUNCHED_BY",
+		"namespace":       "NAMESPACE",
+		"node_labels":     "LABEL",
+		"node":            "NODE",
+		"output_fields":   "NAME, FIELDS",
+		"pod":             "NAME, NAMESPACE, STATUS, LAUNCHED_BY, UTILITY, SHELL/SERVICE",
+		"service_account": "SERVICE_ACCOUNT",
+		"service":         "NAME, NAMESPACE, TYPE, CLUSTER_IP, EXTERNAL_IP, PORTS, LAUNCHED_BY",
+		"size":            "NAME, CPU_LIMIT, MEM_LIMIT, CPU_REQUEST, MEM_REQUEST",
+		"status":          "NAME, STATUS, EXCLUDE",
+		"utility":         "NAME, REPOSITORY, EXEC, HIDDEN, EXCLUDED, SOURCE, ENVIRONMENTS, REQUIRECONFIGMAPS, REQUIRESECRETS, HINT, REMOVE_UPSTREAM",
+		"version":         "SEMVER, BUILD_DATE, GIT_COMMIT, GIT_REF",
+	}
+}
+
+func OutputFieldsList() []objects.OutputFields {
+
+	return []objects.OutputFields{
+		{
+			Name:   "environments",
+			Fields: "NAME,REPOSITORY,EXCLUDED",
+		},
+		{
+			Name:   "ephemeral_sleep",
+			Fields: "NAME,SECONDS",
+		},
+		{
+			Name:   "ingress",
+			Fields: "NAME,NAMESPACE,CLASS,URL,ADDRESS,PORTS,LAUNCHED_BY",
+		},
+		{
+			Name:   "namespace",
+			Fields: "NAMESPACE",
+		},
+		{
+			Name:   "node_labels",
+			Fields: "LABEL",
+		},
+		{
+			Name:   "node",
+			Fields: "NODE",
+		},
+		{
+			Name:   "output_fields",
+			Fields: "NAME,FIELDS",
+		},
+		{
+			Name:   "pod",
+			Fields: "NAME,NAMESPACE,STATUS,LAUNCHED_BY,UTILITY,SHELL/SERVICE",
+		},
+		{
+			Name:   "service_account",
+			Fields: "SERVICE_ACCOUNT",
+		},
+		{
+			Name:   "service",
+			Fields: "NAME,NAMESPACE,TYPE,CLUSTER_IP,EXTERNAL_IP,PORTS,LAUNCHED_BY",
+		},
+		{
+			Name:   "size",
+			Fields: "NAME,CPU_LIMIT,MEM_LIMIT,CPU_REQUEST,MEM_REQUEST",
+		},
+		{
+			Name:   "status",
+			Fields: "NAME,STATUS,PUSH_EXCLUDE",
+		},
+		{
+			Name:   "utility",
+			Fields: "NAME,REPOSITORY,EXEC",
+		},
+		{
+			Name:   "version",
+			Fields: "SEMVER,BUILD_DATE,GIT_COMMIT,GIT_REF",
+		},
+	}
+}

--- a/help/get/get_output_fields_help.go
+++ b/help/get/get_output_fields_help.go
@@ -1,0 +1,27 @@
+package get
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+)
+
+type GetOutputFieldsCmd struct {
+}
+
+func (g *GetOutputFieldsCmd) Short() string {
+	return "Get a list fo the current output fields definitions"
+}
+
+func (g *GetOutputFieldsCmd) Long() string {
+	longText := ""
+	yellow := color.New(color.FgYellow).SprintFunc()
+
+	longText += `EXAMPLE:
+  Display a list of output definition names and their related fields from the configuration file
+`
+
+	longText = fmt.Sprintf("%s\n    > %s\n", longText, yellow(`ktrouble get output-fields`))
+
+	return longText
+}

--- a/help/launch_help.go
+++ b/help/launch_help.go
@@ -45,7 +45,7 @@ func (l *LaunchCmd) Long() string {
   All of the above examples prompt for all the missing parameters.  You can also specify ALL of the
   parameters on the command line, and optionally just return the POD name.
 
-  All of these parameters, except or node-selecotr, need to be set if you want to suppress the prompts.
+  All of these parameters, except or node-selector, need to be set if you want to suppress the prompts.
 
   Parameters:
     - --utility/-u <name>           : The name of the utility to launch, must match the utility name

--- a/help/set/set_output_fields_help.go
+++ b/help/set/set_output_fields_help.go
@@ -1,0 +1,87 @@
+package set
+
+import (
+	"fmt"
+	"ktrouble/defaults"
+	"sort"
+	"strings"
+
+	"github.com/fatih/color"
+)
+
+type SetOutputFieldsCmd struct {
+}
+
+func (s *SetOutputFieldsCmd) Short() string {
+	return "Set default output fields for ktrouble commands"
+}
+
+func (s *SetOutputFieldsCmd) Long() string {
+	longText := ""
+	yellow := color.New(color.FgYellow).SprintFunc()
+
+	longText += `EXAMPLE:
+  Set the default output field for 'environment' commands to 'name,repository,source,hidden'.
+`
+
+	longText = fmt.Sprintf("%s\n    > %s\n\n", longText, yellow(`ktrouble set output-fields --output-name environments --fields 'name,repository,excluded,hidden'`))
+
+	longText += `EXAMPLE:
+  Set the default output for 'pod' commands to 'name,launched_by'
+`
+	longText = fmt.Sprintf("%s\n    > %s\n\n", longText, yellow(`ktrouble set output-fields --output-name pod --fields 'name,launched_by'`))
+
+	longText += `EXAMPLE:
+  Reset to the default output fields for 'pod' commands.
+`
+	longText = fmt.Sprintf("%s\n    > %s\n\n", longText, yellow(`ktrouble set output-fields --output-name pod --fields ''`))
+
+	longText += `EXAMPLE:
+  The possible --output-name and --field combinations are:
+
+  Output Names/Fields:
+
+`
+	validOutputFields := defaults.ValidOutputFields()
+	outputNames := make([]string, 0, len(validOutputFields))
+	for k := range validOutputFields {
+		outputNames = append(outputNames, k)
+	}
+	sort.Strings(outputNames)
+	// I would like to output the validOutputFields 5 at a time, with the first output
+	// containing the 'v' of outputNames and all the rest would be indented 4 spaces plus the
+	// lenggth of the 'v' string.
+	// for _, v := range outputNames {
+	// 	longText += fmt.Sprintf("    - %s: %s\n", v, validOutputFields[v])
+	// }
+	maxKeyLen := 0
+	for _, v := range outputNames {
+		if len(v) > maxKeyLen {
+			maxKeyLen = len(v)
+		}
+	}
+
+	for _, v := range outputNames {
+		items := strings.Split(validOutputFields[v], ",")
+		for i := 0; i < len(items); i += 5 {
+			end := i + 5
+			if end > len(items) {
+				end = len(items)
+			}
+			chunk := items[i:end]
+			line := strings.Join(chunk, ", ")
+
+			if i == 0 {
+				// Pad the key so all colons align
+				paddedKey := fmt.Sprintf("%-*s", maxKeyLen, v)
+				longText += fmt.Sprintf("    - %s: %s\n", paddedKey, line)
+			} else {
+				// Continuation lines with matching indentation
+				indent := strings.Repeat(" ", 7+maxKeyLen)
+				longText += fmt.Sprintf("%s%s\n", indent, line)
+			}
+		}
+	}
+
+	return longText
+}

--- a/objects/environments.go
+++ b/objects/environments.go
@@ -117,7 +117,7 @@ func (en *EnvironmentList) ToTEXT(to TextOptions) string {
 			upperFields := fieldsToUpper(to.Fields)
 			fields = append(fields, upperFields...)
 		} else {
-			fields = []string{"NAME", "REPOSITORY", "EXCLUDED"}
+			fields = to.DefaultFields
 		}
 		if len(to.AdditionalFields) > 0 {
 			fields = append(fields, to.AdditionalFields...)

--- a/objects/ephemeral_sleep.go
+++ b/objects/ephemeral_sleep.go
@@ -63,7 +63,7 @@ func (es *EphemeralSleepList) ToTEXT(to TextOptions) string {
 		if len(to.Fields) > 0 {
 			fields = append(fields, to.Fields...)
 		} else {
-			fields = []string{"NAME", "SECONDS"}
+			fields = to.DefaultFields
 		}
 		if len(to.AdditionalFields) > 0 {
 			fields = append(fields, to.AdditionalFields...)

--- a/objects/ingress.go
+++ b/objects/ingress.go
@@ -69,7 +69,7 @@ func (i *IngressList) ToTEXT(to TextOptions) string {
 			upperFields := fieldsToUpper(to.Fields)
 			fields = append(fields, upperFields...)
 		} else {
-			fields = []string{"NAME", "NAMESPACE", "CLASS", "URL", "ADDRESS", "PORTS", "LAUNCHED_BY"}
+			fields = to.DefaultFields
 		}
 		if len(to.AdditionalFields) > 0 {
 			fields = append(fields, to.AdditionalFields...)

--- a/objects/node.go
+++ b/objects/node.go
@@ -63,7 +63,7 @@ func (n *NodeList) ToTEXT(to TextOptions) string {
 			upperFields := fieldsToUpper(to.Fields)
 			fields = append(fields, upperFields...)
 		} else {
-			fields = []string{"NODE"}
+			fields = to.DefaultFields
 		}
 		table.SetHeader(fields)
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)

--- a/objects/node_labels.go
+++ b/objects/node_labels.go
@@ -60,7 +60,7 @@ func (nl *NodeLabels) ToTEXT(to TextOptions) string {
 			upperFields := fieldsToUpper(to.Fields)
 			fields = append(fields, upperFields...)
 		} else {
-			fields = []string{"LABEL"}
+			fields = to.DefaultFields
 		}
 		table.SetHeader(fields)
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)

--- a/objects/pod.go
+++ b/objects/pod.go
@@ -78,7 +78,7 @@ func (p *PodList) ToTEXT(to TextOptions) string {
 			upperFields := fieldsToUpper(to.Fields)
 			fields = append(fields, upperFields...)
 		} else {
-			fields = []string{"NAME", "NAMESPACE", "STATUS", "LAUNCHED_BY", "UTILITY", "SHELL/SERVICE"}
+			fields = to.DefaultFields
 		}
 		table.SetHeader(fields)
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)

--- a/objects/service.go
+++ b/objects/service.go
@@ -72,7 +72,7 @@ func (s *ServiceList) ToTEXT(to TextOptions) string {
 			upperFields := fieldsToUpper(to.Fields)
 			fields = append(fields, upperFields...)
 		} else {
-			fields = []string{"NAME", "NAMESPACE", "TYPE", "CLUSTER_IP", "EXTERNAL_IP", "PORTS", "LAUNCHED_BY"}
+			fields = to.DefaultFields
 		}
 		table.SetHeader(fields)
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)

--- a/objects/service_account.go
+++ b/objects/service_account.go
@@ -64,7 +64,7 @@ func (sa *ServiceAccountList) ToTEXT(to TextOptions) string {
 			upperFields := fieldsToUpper(to.Fields)
 			fields = append(fields, upperFields...)
 		} else {
-			fields = []string{"SERVICE_ACCOUNT"}
+			fields = to.DefaultFields
 		}
 		table.SetHeader(fields)
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)

--- a/objects/size.go
+++ b/objects/size.go
@@ -69,7 +69,7 @@ func (rs *ResourceSizeList) ToTEXT(to TextOptions) string {
 			upperFields := fieldsToUpper(to.Fields)
 			fields = append(fields, upperFields...)
 		} else {
-			fields = []string{"NAME", "CPU_LIMIT", "MEM_LIMIT", "CPU_REQUEST", "MEM_REQUEST"}
+			fields = to.DefaultFields
 		}
 		table.SetHeader(fields)
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)

--- a/objects/status.go
+++ b/objects/status.go
@@ -68,7 +68,7 @@ func (s *StatusList) ToTEXT(to TextOptions) string {
 			upperFields := fieldsToUpper(to.Fields)
 			fields = append(fields, upperFields...)
 		} else {
-			fields = []string{"NAME", "STATUS", "PUSH_EXCLUDE"}
+			fields = to.DefaultFields
 		}
 		table.SetHeader(fields)
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)

--- a/objects/text_options.go
+++ b/objects/text_options.go
@@ -9,5 +9,6 @@ type (
 		ShowHidden       bool
 		Fields           []string
 		AdditionalFields []string
+		DefaultFields    []string
 	}
 )

--- a/objects/utility.go
+++ b/objects/utility.go
@@ -137,7 +137,7 @@ func (up *UtilityPodList) ToTEXT(to TextOptions) string {
 			upperFields := fieldsToUpper(to.Fields)
 			fields = append(fields, upperFields...)
 		} else {
-			fields = []string{"NAME", "REPOSITORY", "EXEC"}
+			fields = to.DefaultFields
 		}
 		if len(to.AdditionalFields) > 0 {
 			fields = append(fields, to.AdditionalFields...)

--- a/objects/version.go
+++ b/objects/version.go
@@ -66,7 +66,7 @@ func (v *Version) ToTEXT(to TextOptions) string {
 			upperFields := fieldsToUpper(to.Fields)
 			fields = append(fields, upperFields...)
 		} else {
-			fields = []string{"SEMVER", "BUILD_DATE", "GIT_COMMIT", "GIT_REF"}
+			fields = to.DefaultFields
 		}
 		table.SetHeader(fields)
 		table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)


### PR DESCRIPTION
## Description

Allow user to control the output fields for each output type.

## How Has This Been Tested?

Output from each command verified manually

## Screenshots (if appropriate)

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [x] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
- **BREAKING** note on base feature
- Basically whatever formatting we have here, just plain-text
%> command example
- next feature
- note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

- Add output field definitions to the config file
- Allow user to specify the output fields for each output type

### Changes

- Updated a few aliases for commands

### Fixes

- Minor spelling fixes

### Deprecated

### Removed

### Breaking Changes


