### PR TITLE
build macos arm64 and update goreleaser syntax

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,12 +21,13 @@ builds:
       - linux_amd64
       - windows_amd64
       - darwin_amd64
+      - darwin_arm64
 
 archives:
-  - id: general
+  - ids: [general]
     builds:
       - general
-    format: tar.gz
+    formats: [tar.gz]
     wrap_in_directory: true
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
     files:
@@ -36,13 +37,13 @@ checksum:
   name_template: "checksums.txt"
 
 snapshot:
-  name_template: "{{ incpatch .Tag }}-next"
+  version_template: "{{ incpatch .Tag }}-next"
 
 brews:
   - name: ktrouble
     ids:
       - general
-    goarm: "6"
+    goarm: 6
     repository:
       owner: maahsome
       name: homebrew-tap


### PR DESCRIPTION
## Description

Missed building the arm64 version for MacOS

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [x] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
- **BREAKING** note on base feature
- Basically whatever formatting we have here, just plain-text
%> command example
- next feature
- note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

### Changes

- Build arm64 for darwin/MacOS

### Fixes

- Chore: goreleaser syntax changes

### Deprecated

### Removed

### Breaking Changes


