### PR TITLE
remove some old methods from goreleaser file

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,8 +29,6 @@ archives:
     formats: [tar.gz]
     wrap_in_directory: true
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
-    files:
-      - none*  # This preserves the old behavior of only including the binary
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
## Description

Goreleaser still wasn't working with the updated syntax.

## Checklist

If the pull request includes user-facing changes, extra documentation is required:

- [x] If the change is user facing, please ensure you add info in one of the [Changelog Inclusions](#changelog-inclusions) sections.

## Changelog Inclusions

<!-- Text Entered in these sections will appear as it is written, MD formatted -->
<!-- Avoid using the # character as the first character on any line, a trim is -->
<!-- performed on each line when checking for markdown section tags -->
- base feature note
- **BREAKING** note on base feature
- Basically whatever formatting we have here, just plain-text
%> command example
- next feature
- note on next feature
<!-- If there is NO text in a section, no entries will be collected for that section -->

### Additions

### Changes

### Fixes

Chore: get goreleaser working

### Deprecated

### Removed

### Breaking Changes


