### PR TITLE
Add CLI commands to manage resource sizes safely (Vibe Kanban)

### DIFF
--- a/cmd/add/add.go
+++ b/cmd/add/add.go
@@ -11,6 +11,7 @@ import (
 var addHelp = help.AddCmd{}
 var addEnvironmentHelp = help.AddEnvironmentCmd{}
 var addUtilityHelp = help.AddUtilityCmd{}
+var addSizeHelp = help.AddSizeCmd{}
 
 var addCmd = &cobra.Command{
 	Use:     "add",

--- a/cmd/add/add_size.go
+++ b/cmd/add/add_size.go
@@ -1,0 +1,127 @@
+package add
+
+import (
+	"fmt"
+	"ktrouble/common"
+	"ktrouble/defaults"
+	"ktrouble/objects"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// sizeParam is used to store command line parameters
+var sizeParam objects.ResourceSize
+
+// sizeCmd represents the size command
+var sizeCmd = &cobra.Command{
+	Use:     "size",
+	Aliases: defaults.GetSizesAliases,
+	Short:   addSizeHelp.Short(),
+	Long:    addSizeHelp.Long(),
+	Run: func(cmd *cobra.Command, args []string) {
+		if checkAddSizeParams() {
+			s, err := addSize()
+			if err != nil {
+				common.Logger.WithError(err).Error("Failed to add the size definition")
+			}
+			if !c.FormatOverridden {
+				c.OutputFormat = "text"
+			}
+			added := objects.ResourceSizeList{}
+			added = append(added, s)
+			c.OutputData(&added, objects.TextOptions{
+				NoHeaders:     c.NoHeaders,
+				Fields:        c.Fields,
+				DefaultFields: c.OutputFieldsMap["size"],
+			})
+		} else {
+			common.Logger.Error("Parameters passed in have failed checks.  Please review the warnings above")
+		}
+	},
+}
+
+func checkAddSizeParams() bool {
+	allParamsSet := true
+	if len(sizeParam.Name) == 0 {
+		allParamsSet = false
+		common.Logger.Warn("The --name/-n parameter must be set")
+	}
+	if len(sizeParam.LimitsCPU) == 0 {
+		allParamsSet = false
+		common.Logger.Warn("The --limitscpu parameter must be set")
+	}
+	if len(sizeParam.LimitsMEM) == 0 {
+		allParamsSet = false
+		common.Logger.Warn("The --limitsmem parameter must be set")
+	}
+	if len(sizeParam.RequestCPU) == 0 {
+		allParamsSet = false
+		common.Logger.Warn("The --requestcpu parameter must be set")
+	}
+	if len(sizeParam.RequestMEM) == 0 {
+		allParamsSet = false
+		common.Logger.Warn("The --requestmem parameter must be set")
+	}
+
+	if allParamsSet {
+		for _, v := range c.SizeDefs {
+			if sizeParam.Name == v.Name {
+				allParamsSet = false
+				s := objects.ResourceSizeList{}
+				s = append(s, v)
+				common.Logger.Warn("The --name/-n size name clashes with an existing size name, please choose another, or use 'update size' to update the existing size")
+				if !c.FormatOverridden {
+					c.OutputFormat = "text"
+				}
+				c.OutputData(&s, objects.TextOptions{
+					NoHeaders:     c.NoHeaders,
+					Fields:        c.Fields,
+					DefaultFields: c.OutputFieldsMap["size"],
+				})
+				break
+			}
+		}
+	}
+
+	return allParamsSet
+}
+
+func addSize() (objects.ResourceSize, error) {
+	newSize := objects.ResourceSize{
+		Name:       sizeParam.Name,
+		LimitsCPU:  sizeParam.LimitsCPU,
+		LimitsMEM:  sizeParam.LimitsMEM,
+		RequestCPU: sizeParam.RequestCPU,
+		RequestMEM: sizeParam.RequestMEM,
+	}
+
+	c.SizeDefs = append(c.SizeDefs, newSize)
+	viper.Set("resourceSizing", c.SizeDefs)
+	verr := viper.WriteConfig()
+	if verr != nil {
+		common.Logger.WithError(verr).Info("Failed to write config")
+		return newSize, verr
+	}
+
+	c.SizeMap[newSize.Name] = newSize
+	return newSize, nil
+}
+
+func init() {
+	addCmd.AddCommand(sizeCmd)
+
+	sizeCmd.Flags().StringVarP(&sizeParam.Name, "name", "n", "", "Unique name for your size definition")
+	sizeCmd.Flags().StringVar(&sizeParam.LimitsCPU, "limitscpu", "", "CPU limit for the size definition, eg: 250m")
+	sizeCmd.Flags().StringVar(&sizeParam.LimitsMEM, "limitsmem", "", "Memory limit for the size definition, eg: 2Gi")
+	sizeCmd.Flags().StringVar(&sizeParam.RequestCPU, "requestcpu", "", "CPU request for the size definition, eg: 100m")
+	sizeCmd.Flags().StringVar(&sizeParam.RequestMEM, "requestmem", "", "Memory request for the size definition, eg: 512Mi")
+
+	_ = sizeCmd.MarkFlagRequired("name")
+	_ = sizeCmd.MarkFlagRequired("limitscpu")
+	_ = sizeCmd.MarkFlagRequired("limitsmem")
+	_ = sizeCmd.MarkFlagRequired("requestcpu")
+	_ = sizeCmd.MarkFlagRequired("requestmem")
+
+	sizeCmd.Example = fmt.Sprintf("%s\n%s", "ktrouble add size --name small --limitscpu 250m --limitsmem 2Gi --requestcpu 100m --requestmem 512Mi", "ktrouble add size -n medium --limitscpu 500m --limitsmem 4Gi --requestcpu 200m --requestmem 1Gi")
+}

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -11,6 +11,7 @@ import (
 var removeHelp = help.RemoveCmd{}
 var removeEnvironmentHelp = help.RemoveEnvironmentCmd{}
 var removeUtilityHelp = help.RemoveUtilityCmd{}
+var removeSizeHelp = help.RemoveSizeCmd{}
 
 var removeCmd = &cobra.Command{
 	Use:     "remove",

--- a/cmd/remove/remove_size.go
+++ b/cmd/remove/remove_size.go
@@ -1,0 +1,80 @@
+package remove
+
+import (
+	"errors"
+	"ktrouble/ask"
+	"ktrouble/common"
+	"ktrouble/defaults"
+	"ktrouble/objects"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// sizeParam is used to store command line parameters
+var sizeParam objects.ResourceSize
+
+// sizeCmd represents the size command
+var sizeCmd = &cobra.Command{
+	Use:     "size",
+	Aliases: defaults.GetSizesAliases,
+	Short:   removeSizeHelp.Short(),
+	Long:    removeSizeHelp.Long(),
+	Run: func(cmd *cobra.Command, args []string) {
+		err := removeSize()
+		if err != nil {
+			logrus.WithError(err).Error("Failed to remove the size definition")
+		}
+		if !c.FormatOverridden {
+			c.OutputFormat = "text"
+		}
+		c.OutputData(&c.SizeDefs, objects.TextOptions{
+			NoHeaders:     c.NoHeaders,
+			Fields:        c.Fields,
+			DefaultFields: c.OutputFieldsMap["size"],
+		})
+	},
+}
+
+func removeSize() error {
+	if len(sizeParam.Name) == 0 {
+		sizeParam.Name = ask.PromptForResourceSize(c.SizeDefs)
+	}
+
+	if len(sizeParam.Name) == 0 {
+		return errors.New("no size selected")
+	}
+
+	if len(c.SizeDefs) == 1 {
+		return errors.New("cannot remove the last size definition; at least one size must remain")
+	}
+
+	removeIndex := -1
+	for i, v := range c.SizeDefs {
+		if sizeParam.Name == v.Name {
+			removeIndex = i
+			break
+		}
+	}
+
+	if removeIndex == -1 {
+		return errors.New("size name was not found in the existing size definitions")
+	}
+
+	c.SizeDefs = append(c.SizeDefs[:removeIndex], c.SizeDefs[removeIndex+1:]...)
+	viper.Set("resourceSizing", c.SizeDefs)
+	verr := viper.WriteConfig()
+	if verr != nil {
+		common.Logger.WithError(verr).Info("Failed to write config")
+		return verr
+	}
+
+	delete(c.SizeMap, sizeParam.Name)
+	return nil
+}
+
+func init() {
+	removeCmd.AddCommand(sizeCmd)
+	sizeCmd.Flags().StringVarP(&sizeParam.Name, "name", "n", "", "Name of the size definition to remove")
+}

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -11,6 +11,7 @@ import (
 var updateHelp = help.UpdateCmd{}
 var updateEnvironmentHelp = help.UpdateEnvironmentCmd{}
 var updateUtilityHelp = help.UpdateUtilityCmd{}
+var updateSizeHelp = help.UpdateSizeCmd{}
 
 var updateCmd = &cobra.Command{
 	Use:     "update",

--- a/cmd/update/update_size.go
+++ b/cmd/update/update_size.go
@@ -1,0 +1,128 @@
+package update
+
+import (
+	"ktrouble/ask"
+	"ktrouble/common"
+	"ktrouble/defaults"
+	"ktrouble/objects"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// sizeParam is used to store command line parameters
+var sizeParam objects.ResourceSize
+
+// sizeCmd represents the size command
+var sizeCmd = &cobra.Command{
+	Use:     "size",
+	Aliases: defaults.GetSizesAliases,
+	Short:   updateSizeHelp.Short(),
+	Long:    updateSizeHelp.Long(),
+	Run: func(cmd *cobra.Command, args []string) {
+		if checkUpdateSizeParams() {
+			s, err := updateSize()
+			if err != nil {
+				logrus.WithError(err).Error("Failed to update the size definition")
+			}
+			if !c.FormatOverridden {
+				c.OutputFormat = "text"
+			}
+			updated := objects.ResourceSizeList{}
+			updated = append(updated, s)
+			c.OutputData(&updated, objects.TextOptions{
+				NoHeaders:     c.NoHeaders,
+				Fields:        c.Fields,
+				DefaultFields: c.OutputFieldsMap["size"],
+			})
+		} else {
+			common.Logger.Error("Parameters passed in have failed checks.  Please review the warnings above")
+		}
+	},
+}
+
+func checkUpdateSizeParams() bool {
+	allParamsSet := true
+
+	if len(sizeParam.Name) == 0 {
+		sizeParam.Name = ask.PromptForResourceSize(c.SizeDefs)
+	}
+
+	if len(sizeParam.Name) == 0 {
+		allParamsSet = false
+		common.Logger.Warn("No size selected")
+	}
+
+	if len(sizeParam.LimitsCPU) == 0 && len(sizeParam.LimitsMEM) == 0 && len(sizeParam.RequestCPU) == 0 && len(sizeParam.RequestMEM) == 0 {
+		allParamsSet = false
+		common.Logger.Warn("At least one value must be provided to update: --limitscpu, --limitsmem, --requestcpu, or --requestmem")
+	}
+
+	if allParamsSet {
+		found := false
+		for _, v := range c.SizeDefs {
+			if sizeParam.Name == v.Name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			allParamsSet = false
+			common.Logger.Warnf("The --name/-n size name does not match an existing size: %s", sizeParam.Name)
+		}
+	}
+
+	return allParamsSet
+}
+
+func updateSize() (objects.ResourceSize, error) {
+	updatedSize := false
+	updatedDef := objects.ResourceSize{}
+
+	for i, v := range c.SizeDefs {
+		if sizeParam.Name == v.Name {
+			if len(sizeParam.LimitsCPU) > 0 {
+				c.SizeDefs[i].LimitsCPU = sizeParam.LimitsCPU
+				updatedSize = true
+			}
+			if len(sizeParam.LimitsMEM) > 0 {
+				c.SizeDefs[i].LimitsMEM = sizeParam.LimitsMEM
+				updatedSize = true
+			}
+			if len(sizeParam.RequestCPU) > 0 {
+				c.SizeDefs[i].RequestCPU = sizeParam.RequestCPU
+				updatedSize = true
+			}
+			if len(sizeParam.RequestMEM) > 0 {
+				c.SizeDefs[i].RequestMEM = sizeParam.RequestMEM
+				updatedSize = true
+			}
+			updatedDef = c.SizeDefs[i]
+			break
+		}
+	}
+
+	if updatedSize {
+		viper.Set("resourceSizing", c.SizeDefs)
+		verr := viper.WriteConfig()
+		if verr != nil {
+			common.Logger.WithError(verr).Info("Failed to write config")
+			return updatedDef, verr
+		}
+		c.SizeMap[updatedDef.Name] = updatedDef
+	} else {
+		common.Logger.Warnf("The size, %s, was not updated, perhaps a mis-matched name", sizeParam.Name)
+	}
+
+	return updatedDef, nil
+}
+
+func init() {
+	updateCmd.AddCommand(sizeCmd)
+	sizeCmd.Flags().StringVarP(&sizeParam.Name, "name", "n", "", "Name of the size definition to update")
+	sizeCmd.Flags().StringVar(&sizeParam.LimitsCPU, "limitscpu", "", "CPU limit for the size definition, eg: 250m")
+	sizeCmd.Flags().StringVar(&sizeParam.LimitsMEM, "limitsmem", "", "Memory limit for the size definition, eg: 2Gi")
+	sizeCmd.Flags().StringVar(&sizeParam.RequestCPU, "requestcpu", "", "CPU request for the size definition, eg: 100m")
+	sizeCmd.Flags().StringVar(&sizeParam.RequestMEM, "requestmem", "", "Memory request for the size definition, eg: 512Mi")
+}

--- a/help/add/add_size_help.go
+++ b/help/add/add_size_help.go
@@ -1,0 +1,27 @@
+package add
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+)
+
+type AddSizeCmd struct {
+}
+
+func (a *AddSizeCmd) Short() string {
+	return "Add a resource size definition to the ktrouble configuration"
+}
+
+func (a *AddSizeCmd) Long() string {
+	longText := ""
+	yellow := color.New(color.FgYellow).SprintFunc()
+
+	longText += `EXAMPLE:
+  Use 'add size' command to add a new resource sizing definition to your 'config.yaml'
+  file`
+
+	longText = fmt.Sprintf("%s\n\n    > %s\n\n", longText, yellow(`ktrouble add size --name small-plus --limitscpu 300m --limitsmem 3Gi --requestcpu 150m --requestmem 768Mi`))
+
+	return longText
+}

--- a/help/remove/remove_size_help.go
+++ b/help/remove/remove_size_help.go
@@ -1,0 +1,32 @@
+package remove
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+)
+
+type RemoveSizeCmd struct {
+}
+
+func (r *RemoveSizeCmd) Short() string {
+	return "Remove a resource size from the config file"
+}
+
+func (r *RemoveSizeCmd) Long() string {
+	longText := ""
+	yellow := color.New(color.FgYellow).SprintFunc()
+
+	longText += `EXAMPLE:
+  Remove a size definition from your local 'config.yaml' file.
+`
+
+	longText = fmt.Sprintf("%s\n    > %s\n\n", longText, yellow(`ktrouble remove size --name Small`))
+
+	longText += `EXAMPLE:
+  If '--name' is omitted, you will be prompted to choose a size definition to remove.
+`
+	longText = fmt.Sprintf("%s\n    > %s\n", longText, yellow(`ktrouble remove size`))
+
+	return longText
+}

--- a/help/update/update_size_help.go
+++ b/help/update/update_size_help.go
@@ -1,0 +1,32 @@
+package update
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+)
+
+type UpdateSizeCmd struct {
+}
+
+func (u *UpdateSizeCmd) Short() string {
+	return "Update an existing resource size definition in the local config.yaml file"
+}
+
+func (u *UpdateSizeCmd) Long() string {
+	longText := ""
+	yellow := color.New(color.FgYellow).SprintFunc()
+
+	longText += `EXAMPLE:
+  Update the cpu/memory limits for an existing size definition.
+`
+
+	longText = fmt.Sprintf("%s\n    > %s\n\n", longText, yellow(`ktrouble update size --name Small --limitscpu 300m --limitsmem 3Gi`))
+
+	longText += `EXAMPLE:
+  If '--name' is omitted, you will be prompted to choose a size definition to update.
+`
+	longText = fmt.Sprintf("%s\n    > %s\n\n", longText, yellow(`ktrouble update size --requestcpu 150m --requestmem 768Mi`))
+
+	return longText
+}


### PR DESCRIPTION
## Summary
This PR adds first-class resource size management commands so users can maintain `resourceSizing` entries directly from the CLI.

## What Changed
- Added `add size` command support:
  - New command implementation in `cmd/add/add_size.go`
  - Command wiring in `cmd/add/add.go`
  - Help text in `help/add/add_size_help.go`
- Added `update size` command support:
  - New command implementation in `cmd/update/update_size.go`
  - Command wiring in `cmd/update/update.go`
  - Help text in `help/update/update_size_help.go`
- Added `remove size` command support:
  - New command implementation in `cmd/remove/remove_size.go`
  - Command wiring in `cmd/remove/remove.go`
  - Help text in `help/remove/remove_size_help.go`

## Why
The task required enabling modification of the `resourceSizing` section in config (add/update/remove), with safety rules to avoid invalid config states:
- Prevent duplicate size entries
- Prevent deleting the final remaining size entry
- Prompt with `ask` when a size name is not provided

## Implementation Details
- `add size`
  - Requires full size definition input (`name`, `limitscpu`, `limitsmem`, `requestcpu`, `requestmem`)
  - Rejects duplicate names and shows the conflicting existing entry
  - Persists updates to `resourceSizing` via viper config write
- `update size`
  - Uses `ask.PromptForResourceSize(...)` when `--name` is omitted
  - Requires at least one mutable field to be provided
  - Validates selected/provided size exists before applying updates
  - Writes the updated size definition back to config
- `remove size`
  - Uses `ask.PromptForResourceSize(...)` when `--name` is omitted
  - Blocks removal when only one size remains, ensuring at least one definition always exists
  - Removes the selected entry and persists config
- Added command-specific help docs to keep CLI help discoverable and consistent with existing command families.

This PR was written using [Vibe Kanban](https://vibekanban.com)
