### PR TITLE
Fix: remove -n short flag from add size command to avoid namespace conflict

### DIFF
--- a/cmd/add/add_size.go
+++ b/cmd/add/add_size.go
@@ -111,7 +111,7 @@ func addSize() (objects.ResourceSize, error) {
 func init() {
 	addCmd.AddCommand(sizeCmd)
 
-	sizeCmd.Flags().StringVarP(&sizeParam.Name, "name", "n", "", "Unique name for your size definition")
+	sizeCmd.Flags().StringVar(&sizeParam.Name, "name", "", "Unique name for your size definition")
 	sizeCmd.Flags().StringVar(&sizeParam.LimitsCPU, "limitscpu", "", "CPU limit for the size definition, eg: 250m")
 	sizeCmd.Flags().StringVar(&sizeParam.LimitsMEM, "limitsmem", "", "Memory limit for the size definition, eg: 2Gi")
 	sizeCmd.Flags().StringVar(&sizeParam.RequestCPU, "requestcpu", "", "CPU request for the size definition, eg: 100m")


### PR DESCRIPTION
## Summary
- Removed the `-n` short flag from the `add size --name` command to resolve conflict with the global `-n/--namespace` flag
- The `--name` flag now only uses the long form to avoid ambiguity

## Changelog Inclusions

### Additions

### Changes
- `add size` command: `--name` flag no longer has a `-n` short flag

### Fixes
- Fixed flag conflict where `-n` in `add size -n` collided with global `-n/--namespace` flag

### Deprecated

### Removed
- Removed `-n` short flag from `add size --name` parameter

### Breaking Changes

## Test plan
- [ ] Verify `add size --name mysize` works correctly
- [ ] Verify `-n` now only refers to `--namespace` globally
- [ ] Verify no other commands are affected by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)