### PR TITLE
Add interactive prompt for remove environment command

### DIFF
--- a/ask/environment.go
+++ b/ask/environment.go
@@ -1,0 +1,44 @@
+package ask
+
+import (
+	"os"
+
+	"ktrouble/common"
+	"ktrouble/objects"
+
+	"github.com/AlecAivazis/survey/v2"
+)
+
+type (
+	EnvironmentAnswer struct {
+		Environment string `survey:"environment"`
+	}
+)
+
+func PromptForEnvironment(envDefs objects.EnvironmentList) string {
+
+	envArray := []string{}
+
+	for _, v := range envDefs {
+		envArray = append(envArray, v.Name)
+	}
+
+	var envSurvey = []*survey.Question{
+		{
+			Name: "environment",
+			Prompt: &survey.Select{
+				Message: "Choose an environment:",
+				Options: envArray,
+			},
+		},
+	}
+
+	opts := survey.WithStdio(os.Stdin, os.Stderr, os.Stderr)
+
+	envAnswer := &EnvironmentAnswer{}
+	if err := survey.Ask(envSurvey, envAnswer, opts); err != nil {
+		common.Logger.WithError(err).Fatal("No environment selected")
+	}
+
+	return envAnswer.Environment
+}

--- a/cmd/remove/remove_environment.go
+++ b/cmd/remove/remove_environment.go
@@ -1,6 +1,7 @@
 package remove
 
 import (
+	"ktrouble/ask"
 	"ktrouble/common"
 	"ktrouble/defaults"
 	"ktrouble/objects"
@@ -20,24 +21,27 @@ var environmentCmd = &cobra.Command{
 	Short:   removeEnvironmentHelp.Short(),
 	Long:    removeEnvironmentHelp.Long(),
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(environmentParam.Name) > 0 {
-			err := removeOrHideEnvironment()
-			if err != nil {
-				logrus.WithError(err).Error("Failed to remove the environment definition")
-			}
-			if !c.FormatOverridden {
-				c.OutputFormat = "text"
-			}
-			c.OutputData(&c.EnvDefs, objects.TextOptions{
-				NoHeaders:        c.NoHeaders,
-				ShowHidden:       true,
-				Fields:           c.Fields,
-				AdditionalFields: []string{"HIDDEN", "REMOVE_UPSTREAM"},
-				DefaultFields:    c.OutputFieldsMap["environments"],
-			})
-		} else {
-			logrus.Warn("--name/-e environment name must be specified")
+		if len(environmentParam.Name) == 0 {
+			environmentParam.Name = ask.PromptForEnvironment(c.EnvDefs)
 		}
+		if len(environmentParam.Name) == 0 {
+			logrus.Warn("--name/-e environment name must be specified")
+			return
+		}
+		err := removeOrHideEnvironment()
+		if err != nil {
+			logrus.WithError(err).Error("Failed to remove the environment definition")
+		}
+		if !c.FormatOverridden {
+			c.OutputFormat = "text"
+		}
+		c.OutputData(&c.EnvDefs, objects.TextOptions{
+			NoHeaders:        c.NoHeaders,
+			ShowHidden:       true,
+			Fields:           c.Fields,
+			AdditionalFields: []string{"HIDDEN", "REMOVE_UPSTREAM"},
+			DefaultFields:    c.OutputFieldsMap["environments"],
+		})
 	},
 }
 


### PR DESCRIPTION
## Summary
- Added interactive environment selection when `--name` flag is not provided for the `remove environment` command
- Created new `ask/environment.go` module with `PromptForEnvironment` function using survey package
- Refactored `remove environment` command to always prompt when name is missing instead of just warning

## Changelog Inclusions

### Additions
- New `ask/environment.go` package with interactive environment selection prompt
- `PromptForEnvironment` function that presents a list of available environments for user selection

### Changes
- Modified `remove environment` command to prompt for environment selection when `--name` flag is omitted
- Improved user experience by eliminating the need to manually type environment names

### Fixes

### Deprecated

### Removed

### Breaking Changes

## Test plan
- [ ] Run `ktrouble remove environment` without `--name` flag and verify interactive prompt appears
- [ ] Select an environment from the prompt and verify it is removed/hidden correctly
- [ ] Run `ktrouble remove environment --name <env>` and verify it still works as before
- [ ] Verify the output displays correctly with the removed environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)