### PR TITLE
Add get envvars subcommand

### DIFF
--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -18,6 +18,7 @@ var getNodeLabelsHelp = help.GetNodeLabelsCmd{}
 var getOutputFieldsHelp = help.GetOutputFieldsCmd{}
 var getServiceAccountHelp = help.GetServiceAccountCmd{}
 var getSizesHelp = help.GetSizesCmd{}
+var getEnvVarsHelp = help.GetEnvVarsCmd{}
 var getUtilitiesHelp = help.GetUtilitiesCmd{}
 
 var getCmd = &cobra.Command{

--- a/cmd/get/get_envvars.go
+++ b/cmd/get/get_envvars.go
@@ -1,0 +1,52 @@
+package get
+
+import (
+	"fmt"
+	"text/tabwriter"
+	"os"
+
+	"ktrouble/defaults"
+
+	"github.com/spf13/cobra"
+)
+
+type envVarEntry struct {
+	Name        string
+	Description string
+}
+
+var ktroublEnvVars = []envVarEntry{
+	{"GIT_TOKEN", "Git authentication token (name overridable via config GitTokenVar)"},
+	{"KUBECONFIG", "Path to kubernetes config file"},
+	{"KTROUBLE_CONFIG", "Config file path override"},
+	{"KTROUBLE_DEFAULT_INGRESS_TEMPLATE", "Custom ingress template file name"},
+	{"KTROUBLE_DEFAULT_SERVICE_TEMPLATE", "Custom service template file name"},
+	{"KTROUBLE_DEFAULT_TEMPLATE", "Custom pod template file name"},
+	{"KTROUBLE_PAGER", "Custom pager for diffs"},
+	{"NAMESPACE", "Default namespace (overridden by --namespace flag)"},
+	{"PAGER", "Fallback pager for diffs"},
+	{"USER", "Username label for pod filtering and creation"},
+	{"XDG_CONFIG_HOME", "XDG Base Directory for config file location"},
+}
+
+// envVarsCmd represents the envvars command
+var envVarsCmd = &cobra.Command{
+	Use:     "envvars",
+	Aliases: defaults.GetEnvVarsAliases,
+	Short:   getEnvVarsHelp.Short(),
+	Long:    getEnvVarsHelp.Long(),
+	Run: func(cmd *cobra.Command, args []string) {
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+		if !c.NoHeaders {
+			fmt.Fprintln(w, "VARIABLE\tDESCRIPTION")
+		}
+		for _, ev := range ktroublEnvVars {
+			fmt.Fprintf(w, "%s\t%s\n", ev.Name, ev.Description)
+		}
+		w.Flush()
+	},
+}
+
+func init() {
+	getCmd.AddCommand(envVarsCmd)
+}

--- a/defaults/aliases.go
+++ b/defaults/aliases.go
@@ -16,6 +16,7 @@ var GetServiceAccountsAliases = []string{"serviceaccounts", "sa"}
 var GetServicesAliases = []string{"service", "svc"}
 var GetSizesAliases = []string{"size", "requests", "request", "limit", "limits"}
 var GetSleepAliases = []string{"ephemeral_sleep", "uptime"}
+var GetEnvVarsAliases = []string{"envvar"}
 var GetUtilitesAliases = []string{"utility", "utils", "util", "container", "containers", "image", "images"}
 var LaunchAliases = []string{"create", "apply", "pod", "l"}
 var OutputFieldsAliases = []string{"of", "fields", "field", "output-field"}

--- a/help/get/get_envvars_help.go
+++ b/help/get/get_envvars_help.go
@@ -1,0 +1,27 @@
+package get
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+)
+
+type GetEnvVarsCmd struct {
+}
+
+func (g *GetEnvVarsCmd) Short() string {
+	return "Get a list of environment variables used by ktrouble"
+}
+
+func (g *GetEnvVarsCmd) Long() string {
+	longText := ""
+	yellow := color.New(color.FgYellow).SprintFunc()
+
+	longText += `EXAMPLE:
+  Display a list of environment variables recognized by ktrouble
+`
+
+	longText = fmt.Sprintf("%s\n    > %s\n", longText, yellow(`ktrouble get envvars`))
+
+	return longText
+}


### PR DESCRIPTION
## Summary
- Adds new `get envvars` subcommand (with `envvar` alias) to list all environment variables recognized by ktrouble
- Provides descriptions for each environment variable
- Uses tabular output format consistent with other get commands

## Changelog Inclusions

### Additions
- New `get envvars` subcommand to display all ktrouble environment variables with descriptions
- Command aliases: `envvar`
- Lists 11 environment variables: `GIT_TOKEN`, `KUBECONFIG`, `KTROUBLE_CONFIG`, `KTROUBLE_DEFAULT_INGRESS_TEMPLATE`, `KTROUBLE_DEFAULT_SERVICE_TEMPLATE`, `KTROUBLE_DEFAULT_TEMPLATE`, `KTROUBLE_PAGER`, `NAMESPACE`, `PAGER`, `USER`, `XDG_CONFIG_HOME`

### Changes
_None_

### Fixes
_None_

### Deprecated
_None_

### Removed
_None_

### Breaking Changes
_None_

## Test plan
- [ ] Run `ktrouble get envvars` and verify all environment variables are listed
- [ ] Run `ktrouble get envvar` (alias) and verify it works
- [ ] Verify tabular output format with headers
- [ ] Test with `--no-headers` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)